### PR TITLE
Fix adjacent_find

### DIFF
--- a/include/nanorange/algorithm/adjacent_find.hpp
+++ b/include/nanorange/algorithm/adjacent_find.hpp
@@ -38,7 +38,7 @@ private:
             ++next;
         }
 
-        return first;
+        return next;
     }
 
 public:


### PR DESCRIPTION
Adjacent_find returns one element before the end instead of the end in the case when the end of the function is reached. This can be fixed by returning next, instead.