### PR TITLE
Implement istream range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,8 @@ target_sources(nanorange INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/memory/uninitialized_move.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/memory/uninitialized_value_construct.hpp
 
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/ranges/istream_range.hpp
+
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/view/interface.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/view/subrange.hpp
 

--- a/include/nanorange/ranges.hpp
+++ b/include/nanorange/ranges.hpp
@@ -19,5 +19,6 @@
 #include <nanorange/detail/ranges/primitives.hpp>
 #include <nanorange/iterator/operations.hpp>
 #include <nanorange/functional.hpp>
+#include <nanorange/ranges/istream_range.hpp>
 
 #endif

--- a/include/nanorange/ranges/istream_range.hpp
+++ b/include/nanorange/ranges/istream_range.hpp
@@ -1,0 +1,123 @@
+// nanorange/ranges/istream_range.hpp
+//
+// Copyright (c) 2018 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_RANGES_ISTREAM_RANGE_HPP_INCLUDED
+#define NANORANGE_RANGES_ISTREAM_RANGE_HPP_INCLUDED
+
+#include <nanorange/detail/iterator/traits.hpp>
+#include <nanorange/iterator/default_sentinel.hpp>
+
+#include <iosfwd>
+
+NANO_BEGIN_NAMESPACE
+
+template <typename T, typename CharT = char, typename Traits = std::char_traits<CharT>,
+          typename Distance = std::ptrdiff_t>
+class istream_range {
+public:
+
+    class iterator {
+    public:
+        using iterator_category = ranges::input_iterator_tag;
+        using difference_type = Distance;
+        using value_type = T;
+        using reference = const T&;
+        using pointer = const T*;
+        using char_type = CharT;
+        using traits = Traits;
+
+        constexpr iterator() = default;
+
+        explicit iterator(istream_range& rng)
+            : rng_(std::addressof(rng))
+        {}
+
+        reference operator*() const { return rng_->value_; }
+
+        pointer operator->() const { return std::addressof(rng_->value_); }
+
+        iterator& operator++()
+        {
+            rng_->next();
+            return *this;
+        }
+
+        iterator operator++(int)
+        {
+            auto tmp = *this;
+            this->operator++();
+            return tmp;
+        }
+
+        friend bool operator==(const iterator& lhs, const iterator& rhs)
+        {
+            return lhs.rng_ == rhs.rng_;
+        }
+
+        friend bool operator!=(const iterator& lhs, const iterator& rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator==(const iterator& lhs, default_sentinel)
+        {
+            return lhs.rng_->done();
+        }
+
+        friend bool operator!=(const iterator& lhs, default_sentinel rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator==(default_sentinel, const iterator& rhs)
+        {
+            return rhs.rng_->done();
+        }
+
+        friend bool operator!=(default_sentinel lhs, const iterator& rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+    private:
+        istream_range* rng_ = nullptr;
+    };
+
+    using sentinel = default_sentinel;
+    using istream_type = std::basic_istream<CharT, Traits>;
+
+    constexpr istream_range() = default;
+
+    istream_range(istream_type& s)
+        : in_stream_(std::addressof(s))
+    {
+        next();
+    }
+
+    iterator begin() { return iterator{*this}; }
+
+    sentinel end() { return {}; }
+
+
+private:
+    void next()
+    {
+        *in_stream_ >> value_;
+        if (in_stream_->fail()) {
+            in_stream_ = nullptr;
+        }
+    }
+
+    bool done() const { return in_stream_ == nullptr; }
+
+    istream_type* in_stream_ = nullptr;
+    // TODO: wrap this in semiregular once we have it
+    T value_{};
+};
+
+NANO_END_NAMESPACE
+
+#endif

--- a/include/nanorange/ranges/istream_range.hpp
+++ b/include/nanorange/ranges/istream_range.hpp
@@ -64,7 +64,7 @@ public:
 
         friend bool operator==(const iterator& lhs, default_sentinel)
         {
-            return lhs.rng_->done();
+            return lhs.done();
         }
 
         friend bool operator!=(const iterator& lhs, default_sentinel rhs)
@@ -74,7 +74,7 @@ public:
 
         friend bool operator==(default_sentinel, const iterator& rhs)
         {
-            return rhs.rng_->done();
+            return rhs.done();
         }
 
         friend bool operator!=(default_sentinel lhs, const iterator& rhs)
@@ -83,6 +83,11 @@ public:
         }
 
     private:
+        bool done() const
+        {
+            return rng_ == nullptr || rng_->in_stream_ == nullptr;
+        }
+
         istream_range* rng_ = nullptr;
     };
 
@@ -111,10 +116,7 @@ private:
         }
     }
 
-    bool done() const { return in_stream_ == nullptr; }
-
     istream_type* in_stream_ = nullptr;
-    // TODO: wrap this in semiregular once we have it
     T value_{};
 };
 

--- a/include/nanorange/ranges/istream_range.hpp
+++ b/include/nanorange/ranges/istream_range.hpp
@@ -96,7 +96,7 @@ public:
 
     constexpr istream_range() = default;
 
-    istream_range(istream_type& s)
+    explicit istream_range(istream_type& s)
         : in_stream_(std::addressof(s))
     {
         next();
@@ -106,12 +106,10 @@ public:
 
     sentinel end() { return {}; }
 
-
 private:
     void next()
     {
-        *in_stream_ >> value_;
-        if (in_stream_->fail()) {
+        if (!(*in_stream_ >> value_)) {
             in_stream_ = nullptr;
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -160,6 +160,8 @@ add_executable(test_nanorange
     memory/uninitialized_move.cpp
     memory/uninitialized_value_construct.cpp
 
+    ranges/istream_range.cpp
+
     range_access.cpp
 
     utility/common_type.cpp

--- a/test/ranges/istream_range.cpp
+++ b/test/ranges/istream_range.cpp
@@ -50,5 +50,5 @@ TEST_CASE("rng.istream_range")
     constexpr const char test[] = "abcd3210";
     std::istringstream ss{test};
     ::check_equal(ranges::istream_range<moveonly>(ss),
-                  ranges::subrange(test, test + sizeof(test) - 1));
+                  ranges::make_subrange(test, test + sizeof(test) - 1));
 }

--- a/test/ranges/istream_range.cpp
+++ b/test/ranges/istream_range.cpp
@@ -1,0 +1,54 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014-present
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <nanorange/ranges/istream_range.hpp>
+#include <sstream>
+#include "../catch.hpp"
+#include "../test_utils.hpp"
+#include <nanorange/algorithm/equal.hpp>
+
+using namespace nano;
+
+namespace {
+
+struct moveonly {
+    char c;
+
+    moveonly() = default;
+
+    moveonly(moveonly&&) = default;
+
+    moveonly& operator=(moveonly&&)& = default;
+
+    operator char() const
+    {
+        return c;
+    }
+
+    friend std::istream& operator>>(std::istream& is, moveonly& m)
+    {
+        is.get(m.c);
+        return is;
+    }
+};
+
+}
+
+static_assert(InputRange<ranges::istream_range<int>>, "");
+static_assert(InputRange<ranges::istream_range<moveonly>>, "");
+
+TEST_CASE("rng.istream_range")
+{
+    constexpr const char test[] = "abcd3210";
+    std::istringstream ss{test};
+    ::check_equal(ranges::istream_range<moveonly>(ss),
+                  ranges::subrange(test, test + sizeof(test) - 1));
+}

--- a/test/ranges/istream_range.cpp
+++ b/test/ranges/istream_range.cpp
@@ -47,8 +47,26 @@ static_assert(InputRange<ranges::istream_range<moveonly>>, "");
 
 TEST_CASE("rng.istream_range")
 {
-    constexpr const char test[] = "abcd3210";
-    std::istringstream ss{test};
-    ::check_equal(ranges::istream_range<moveonly>(ss),
-                  ranges::make_subrange(test, test + sizeof(test) - 1));
+    {
+        constexpr const char test[] = "abcd3210";
+        std::istringstream ss{test};
+        ::check_equal(ranges::istream_range<moveonly>(ss),
+                      ranges::make_subrange(test, test + sizeof(test) - 1));
+    }
+
+    // Default-constructed istream_ranges are empty
+    {
+        ranges::istream_range<int> isr{};
+        CHECK(ranges::distance(isr) == 0);
+    }
+
+    // Default-constructed iterators can be compared
+    {
+        constexpr ranges::istream_range<int>::iterator iter{};
+        constexpr ranges::default_sentinel sent{};
+        CHECK(iter == sent);
+        CHECK(sent == iter);
+        CHECK_FALSE(iter != sent);
+        CHECK_FALSE(sent != iter);
+    }
 }

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -204,7 +204,6 @@ static_assert(!ranges::BidirectionalIterator<int>, "");
 static_assert(ranges::RandomAccessIterator<int*>, "");
 static_assert(!ranges::RandomAccessIterator<int>, "");
 
-// FIXME: Re-enable when we have istream_range
 static_assert(ranges::View<ranges::istream_range<int>>, "");
 static_assert(ranges::InputIterator<ranges::iterator_t<ranges::istream_range<int>>>, "");
 static_assert(!ranges::View<int>, "");

--- a/test/utility/concepts.cpp
+++ b/test/utility/concepts.cpp
@@ -205,8 +205,8 @@ static_assert(ranges::RandomAccessIterator<int*>, "");
 static_assert(!ranges::RandomAccessIterator<int>, "");
 
 // FIXME: Re-enable when we have istream_range
-//static_assert(ranges::View<ranges::istream_range<int>>, "");
-//static_assert(ranges::InputIterator<ranges::iterator_t<ranges::istream_range<int>>>, "");
+static_assert(ranges::View<ranges::istream_range<int>>, "");
+static_assert(ranges::InputIterator<ranges::iterator_t<ranges::istream_range<int>>>, "");
 static_assert(!ranges::View<int>, "");
 
 static_assert(ranges::CommonRange<std::vector<int> >, "");


### PR DESCRIPTION
This uses the Range-V3 approach of storing the basic_istream pointer and the cached value in the range object itself, rather than the P1035 approach of reusing istream_iterator.

This seems to work okay in local testing -- or at least it passes the Range-V3 istream_range test, which is also added in this commit. A few more thorough tests would probably be a good idea.

One caveat is that this implementation currently requires that the value type of the range is default constructible. ~~~Once we add the semiregular wrapper required for Views, we can re-use it here to remove this restriction.~~~ EDIT: I was wrong, thanks @CaseyCarter. (But `semiregular` might at least save us from default-constructing a `T` when we default-construct an `istream_range`, which is obviously what I meant to say the first time...)

