### PR TITLE
Stable partition fixes

### DIFF
--- a/include/nanorange/algorithm/stable_partition.hpp
+++ b/include/nanorange/algorithm/stable_partition.hpp
@@ -149,7 +149,8 @@ public:
     std::enable_if_t<
         BidirectionalIterator<I> &&
         Sentinel<S, I> &&
-        IndirectUnaryPredicate<Pred, projected<I, Proj>>, I>
+        IndirectUnaryPredicate<Pred, projected<I, Proj>> &&
+        Permutable<I>, I>
     operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
     {
         return stable_partition_fn::impl(std::move(first), std::move(last),
@@ -159,7 +160,8 @@ public:
     template <typename Rng, typename Pred, typename Proj = identity>
     std::enable_if_t<
         BidirectionalRange<Rng> &&
-        IndirectUnaryPredicate<Pred, projected<iterator_t<Rng>, Proj>>,
+        IndirectUnaryPredicate<Pred, projected<iterator_t<Rng>, Proj>> &&
+        Permutable<iterator_t<Rng>>,
     safe_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {

--- a/include/nanorange/detail/memory/temporary_vector.hpp
+++ b/include/nanorange/detail/memory/temporary_vector.hpp
@@ -38,7 +38,6 @@ public:
           end_(other.end_),
           end_cap_(other.end_cap_)
     {
-        other.start_.reset();
         other.end_ = nullptr;
         other.end_cap_ = nullptr;
     }
@@ -53,7 +52,7 @@ public:
 
     ~temporary_vector()
     {
-        clear();
+        nano::destroy(begin(), end());
     }
 
     std::size_t size() const { return end_ - start_.get(); }


### PR DESCRIPTION
 * stable_partition: Add missing Permutable constraint
 * temporary_vector: Remove redundant unique_ptr::reset() in move ctor
 * temporary_vector: Don't bother resetting end_ in destructor, we're just about to die

Thanks @caseycarter for the review