### PR TITLE
Try to reduce our std includes

### DIFF
--- a/include/nanorange/algorithm/lexicographical_compare.hpp
+++ b/include/nanorange/algorithm/lexicographical_compare.hpp
@@ -9,9 +9,6 @@
 
 #include <nanorange/ranges.hpp>
 
-
-#include <algorithm>
-
 NANO_BEGIN_NAMESPACE
 
 namespace detail {

--- a/include/nanorange/detail/concepts/core.hpp
+++ b/include/nanorange/detail/concepts/core.hpp
@@ -10,7 +10,7 @@
 #include <nanorange/detail/macros.hpp>
 #include <nanorange/type_traits.hpp>
 
-#include <functional>
+#include <utility>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/detail/functional/comparisons.hpp
+++ b/include/nanorange/detail/functional/comparisons.hpp
@@ -11,6 +11,7 @@
 #include <nanorange/detail/concepts/core.hpp>
 
 #include <functional>
+#include <utility>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/detail/functional/decay_copy.hpp
+++ b/include/nanorange/detail/functional/decay_copy.hpp
@@ -9,8 +9,8 @@
 
 #include <nanorange/detail/macros.hpp>
 
-#include <functional>
 #include <type_traits>
+#include <utility>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/detail/functional/identity.hpp
+++ b/include/nanorange/detail/functional/identity.hpp
@@ -9,8 +9,8 @@
 
 #include <nanorange/detail/macros.hpp>
 
-#include <functional>
 #include <type_traits>
+#include <utility>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/detail/functional/invoke.hpp
+++ b/include/nanorange/detail/functional/invoke.hpp
@@ -7,10 +7,10 @@
 #ifndef NANORANGE_DETAIL_FUNCTIONAL_INVOKE_HPP_INCLUDED
 #define NANORANGE_DETAIL_FUNCTIONAL_INVOKE_HPP_INCLUDED
 
-#include <functional>
-
 #include <nanorange/detail/macros.hpp>
 #include <nanorange/detail/type_traits.hpp>
+
+#include <functional>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/detail/iterator/iter_move.hpp
+++ b/include/nanorange/detail/iterator/iter_move.hpp
@@ -21,9 +21,7 @@ void iter_move();
 struct fn {
 private:
     template <typename T>
-    static constexpr auto impl(T&& t, priority_tag<2>) /*noexcept(
-        noexcept(static_cast<decltype(iter_move(t))>(iter_move(t))))
-        -> decltype(static_cast<decltype(iter_move(t))>(iter_move(t)))*/
+    static constexpr auto impl(T&& t, priority_tag<2>)
         noexcept(noexcept(iter_move(t)))
         -> decltype(iter_move(t))
     {

--- a/include/nanorange/detail/macros.hpp
+++ b/include/nanorange/detail/macros.hpp
@@ -7,6 +7,8 @@
 #ifndef NANORANGE_DETAIL_MACROS_HPP_INCLUDED
 #define NANORANGE_DETAIL_MACROS_HPP_INCLUDED
 
+#include <ciso646>
+
 #if (__cplusplus >= 201703) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #define NANO_HAVE_CPP17
 #endif
@@ -79,5 +81,21 @@ constexpr T static_const_<T>::value;
 } // namespace detail
 
 NANO_END_NAMESPACE
+
+#if defined(_LIBCPP_VERSION)
+#define NANO_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_NAMESPACE_STD
+#define NANO_END_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+#elif defined(_MSVC_STL_VERSION)
+#define NANO_BEGIN_NAMESPACE_STD _STD_BEGIN
+#define NANO_END_NAMESPACE_STD _STD_END
+#elif defined(_GLIBCXX_DEBUG)
+#ifndef NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#endif
+#else
+#define NANO_BEGIN_NAMESPACE_STD namespace std {
+#define NANO_END_NAMESPACE_STD }
+#endif
+
 
 #endif

--- a/include/nanorange/detail/ranges/concepts.hpp
+++ b/include/nanorange/detail/ranges/concepts.hpp
@@ -10,12 +10,23 @@
 #include <nanorange/detail/ranges/begin_end.hpp>
 #include <nanorange/detail/ranges/primitives.hpp>
 
-// These are, sadly, needed for view-predicate specialisations,
-// because we're not allowed to forward-declare std classes
-
 #include <initializer_list>
+
+// Avoid dragging in the large <set> and <unordered_set> headers
+// This is technically undefined behaviour: define the symbol
+// NANORANGE_NO_STD_FORWARD_DECLARATIONS
+// to enforce standard-compliant mode
+#ifndef NANORANGE_NO_STD_FORWARD_DECLARATIONS
+NANO_BEGIN_NAMESPACE_STD
+template <typename, typename, typename> class set;
+template <typename, typename, typename> class multiset;
+template <typename, typename, typename, typename> class unordered_set;
+template <typename, typename, typename, typename> class unordered_multiset;
+NANO_END_NAMESPACE_STD
+#else
 #include <set>
 #include <unordered_set>
+#endif
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/iterator/ostream_iterator.hpp
+++ b/include/nanorange/iterator/ostream_iterator.hpp
@@ -9,7 +9,9 @@
 
 #include <nanorange/detail/macros.hpp>
 
-#include <string> // for char_traits
+#include <iosfwd>
+#include <iterator>
+#include <memory>
 
 NANO_BEGIN_NAMESPACE
 

--- a/include/nanorange/iterator/ostreambuf_iterator.hpp
+++ b/include/nanorange/iterator/ostreambuf_iterator.hpp
@@ -10,7 +10,7 @@
 #include <nanorange/detail/macros.hpp>
 
 #include <iosfwd> // for basic_streambuf
-#include <string> // for char_traits
+#include <iterator>
 
 NANO_BEGIN_NAMESPACE
 


### PR DESCRIPTION
NanoRange (sadly) takes a long time to compile: we shouldn't make this worse by including things we don't really need.

In particular, we only need forward declarations of `std::set` and `std::multiset` and the unordered_ versions -- so we can violate the C++ standard by forward declaring these to avoid including the entire headers.

This can be disabled by defining `NANORANGE_NO_STD_FORWARD_DECLARATIONS`.

On my system, this reduces the time taken to compile an empty file which just does #include <nanorange.hpp> from ~3s to ~2s, which is a decent improvement although obviously still not great.

The remaining standard headers that we use and absolutely can't do without are:

  * `type_traits` - used for concept definitions, `enable_if` etc
  * `functional` - for std::forward, std::move and other things
  * `iterator` - needed for `std::iterator_traits` and the category tags
  * `string_view` - (in C++17) needed for special-casing in begin/end CPOs, so that we can call algorithms on rvalue string_views
  * `initializer_list` - needed for min and max overloads, and probably other places where it's technically UB not to include it
  * `iosfwd` - for the various *buf_iterators
  * `cassert` - well I guess we could do without it, but it's tiny anyway
  * `memory` - we use `unique_ptr` in `temporary_vector`
  * `new` - for `std::nothrow`, and probably cos it's UB not to
  * `random` - `std::uniform_int_distribution` is used in `shuffle`. I wish we could get rid of this one.

The one (large) header we're currently including but eventually won't need is `algorithm` -- this can go away once we finally implement stable_sort, nth_element and inplace_merge.