### PR TITLE
Require C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,7 @@ matrix:
     # Linux builds
     #
     # GCC 9
-    - env: COMPILER=g++-9 CPP=17 BUILD_SINGLE_HEADER=true
-      addons:
-        apt:
-          packages:
-            - g++-9
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - env: COMPILER=g++-9 CPP=14
+    - env: COMPILER=g++-9 BUILD_SINGLE_HEADER=true
       addons:
         apt:
           packages:
@@ -49,15 +41,7 @@ matrix:
             - ubuntu-toolchain-r-test
 
     # GCC 8
-    - env: COMPILER=g++-8 CPP=17
-      addons:
-        apt:
-          packages:
-            - g++-8
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - env: COMPILER=g++-8 CPP=14
+    - env: COMPILER=g++-8
       addons:
         apt:
           packages:
@@ -66,51 +50,16 @@ matrix:
             - ubuntu-toolchain-r-test
 
     # GCC 7
-    - env: COMPILER=g++-7 CPP=17
+    - env: COMPILER=g++-7
       addons:
         apt:
           packages:
             - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-
-    - env: COMPILER=g++-7 CPP=14
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
-
-    # GCC 6
-    - env: COMPILER=g++-6 CPP=14
-      addons:
-        apt:
-          packages:
-            - g++-6
-          sources:
-            - ubuntu-toolchain-r-test
-
-    # GCC 5
-    - env: COMPILER=g++-5 CPP=14
-      addons:
-        apt:
-          packages:
-            - g++-5
           sources:
             - ubuntu-toolchain-r-test
 
     # Clang 8
-    - env: COMPILER=clang++-8 CPP=17
-      addons:
-        apt:
-          packages:
-            - clang-8
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-8
-
-    - env: COMPILER=clang++-8 CPP=14
+    - env: COMPILER=clang++-8
       addons:
         apt:
           packages:
@@ -120,16 +69,7 @@ matrix:
             - llvm-toolchain-trusty-8
 
     # Clang 7
-    - env: COMPILER=clang++-7 CPP=17
-      addons:
-        apt:
-          packages:
-            - clang-7
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
-
-    - env: COMPILER=clang++-7 CPP=14
+    - env: COMPILER=clang++-7
       addons:
         apt:
           packages:
@@ -139,16 +79,7 @@ matrix:
             - llvm-toolchain-trusty-7
 
     # Clang 6
-    - env: COMPILER=clang++-6.0 CPP=17
-      addons:
-        apt:
-          packages:
-            - clang-6.0
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
-
-    - env: COMPILER=clang++-6.0 CPP=14
+    - env: COMPILER=clang++-6.0
       addons:
         apt:
           packages:
@@ -158,7 +89,7 @@ matrix:
             - llvm-toolchain-trusty-6.0
 
     # Clang 5
-    - env: COMPILER=clang++-5.0 CPP=17
+    - env: COMPILER=clang++-5.0
       addons:
         apt:
           packages:
@@ -166,84 +97,25 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-5.0
-
-    - env: COMPILER=clang++-5.0 CPP=14
-      addons:
-        apt:
-          packages:
-            - clang-5.0
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-
-    # Clang 4
-    - env: COMPILER=clang++-4.0 CPP=14
-      addons:
-        apt:
-          packages:
-            - clang-4.0
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-
-    # Clang 3.9
-    - env: COMPILER=clang++-3.9 CPP=14
-      addons:
-        apt:
-          packages:
-            - clang-3.9
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.9
-
-    # Clang 3.8
-    - env: COMPILER=clang++-3.8 CPP=14
-      addons:
-        apt:
-          packages:
-            - clang-3.8
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
 
     #
     # Mac OS builds
     #
     - os: osx
       osx_image: xcode10.2
-      env: COMPILER=clang++ CPP=17
-
-    - os: osx
-      osx_image: xcode10.2
-      env: COMPILER=clang++ CPP=14
+      env: COMPILER=clang++
 
     - os: osx
       osx_image: xcode10.1
-      env: COMPILER=clang++ CPP=17
-
-    - os: osx
-      osx_image: xcode10.1
-      env: COMPILER=clang++ CPP=14
+      env: COMPILER=clang++
 
     - os: osx
       osx_image: xcode9.3
-      env: COMPILER=clang++ CPP=17
-
-    - os: osx
-      osx_image: xcode9.3
-      env: COMPILER=clang++ CPP=14
+      env: COMPILER=clang++
 
     - os: osx
       osx_image: xcode9.2
-      env: COMPILER=clang++ CPP=17
-
-    - os: osx
-      osx_image: xcode9.2
-      env: COMPILER=clang++ CPP=14
-
-    - os: osx
-      osx_image: xcode8.3
-      env: COMPILER=clang++ CPP=14
+      env: COMPILER=clang++
 
 install:
   - DEPS_DIR="${HOME}/deps"
@@ -258,13 +130,7 @@ install:
   ############################################################################
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "${CXX%%+*}" == "clang" ]]; then
-      if   [[ "${CXX}" == "clang++-3.5" ]]; then LLVM_VERSION="3.5.2";
-      elif [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
-      elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
-      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
-      elif [[ "${CXX}" == "clang++-4.0" ]]; then LLVM_VERSION="4.0.1";
-      elif [[ "${CXX}" == "clang++-5.0" ]]; then LLVM_VERSION="5.0.2";
+      if [[ "${CXX}" == "clang++-5.0" ]]; then LLVM_VERSION="5.0.2";
       elif [[ "${CXX}" == "clang++-6.0" ]]; then LLVM_VERSION="6.0.0";
       elif [[ "${CXX}" == "clang++-7" ]]; then LLVM_VERSION="7.0.0";
       elif [[ "${CXX}" == "clang++-8" ]]; then LLVM_VERSION="8.0.0";
@@ -288,7 +154,7 @@ before_script:
   - cd $TRAVIS_BUILD_DIR
   - mkdir -p -v build
   - cd build
-  - cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_CXX_STANDARD=$CPP
+  - cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=$COMPILER
 
 script:
   - cmake --build . --target test_nanorange -- -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,10 +113,6 @@ matrix:
       osx_image: xcode9.3
       env: COMPILER=clang++
 
-    - os: osx
-      osx_image: xcode9.2
-      env: COMPILER=clang++
-
 install:
   - DEPS_DIR="${HOME}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ target_sources(nanorange INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/view.hpp
 )
 target_include_directories(nanorange INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_compile_features(nanorange INTERFACE cxx_std_14)
+target_compile_features(nanorange INTERFACE cxx_std_17)
 
 
 if (MSVC)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Standard](https://img.shields.io/badge/c%2B%2B-14/17/20-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
+[![Standard](https://img.shields.io/badge/c%2B%2B-17/20-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-BSL-blue.svg)](http://www.boost.org/LICENSE_1_0.txt)
 [![Build Status](https://travis-ci.org/tcbrindle/NanoRange.svg?branch=master)](https://travis-ci.org/tcbrindle/NanoRange)
 [![Build status](https://ci.appveyor.com/api/projects/status/6vciaaskslg34pux/branch/master?svg=true)](https://ci.appveyor.com/project/tcbrindle/nanorange/branch/master) [![download](https://img.shields.io/badge/latest-download-blue.svg)](https://github.com/tcbrindle/NanoRange/raw/master/single_include/nanorange.hpp) 
@@ -8,7 +8,7 @@
 
 # NanoRange #
 
-NanoRange is a C++14 implementation of the C++20 Ranges proposals (formerly the
+NanoRange is a C++17 implementation of the C++20 Ranges proposals (formerly the
 Ranges TS). It provides SFINAE-based implementations of all the proposed Concepts,
 and constrained and range-based versions the algorithms in the `<algorithm>`
 standard library header.
@@ -43,8 +43,8 @@ vcpkg install nanorange --head
 
 ## Compatibility ##
 
-NanoRange requires a conforming C++14 compiler, and is
-[tested](https://travis-ci.org/tcbrindle/nanorange) with GCC 5.4 and Clang 3.8
+NanoRange requires a conforming C++17 compiler, and is
+[tested](https://travis-ci.org/tcbrindle/nanorange) with GCC 7 and Clang 4.0
 and newer. Older versions may work in some cases, but this is not guaranteed.
 
 In addition, NanoRange works with MSVC 2017 version 15.9. Note that

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,9 @@ environment:
       generator: Visual Studio 15 2017
       standard: 17
 
-    - platform: x86
-      generator: Visual Studio 15 2017
-      standard: 14
-
     - platform: x64
       generator: Visual Studio 15 2017 Win64
       standard: 17
-
-    - platform: x64
-      generator: Visual Studio 15 2017 Win64
-      standard: 14
 
 install:
 - mkdir cmake-build

--- a/include/nanorange/algorithm/count.hpp
+++ b/include/nanorange/algorithm/count.hpp
@@ -65,19 +65,6 @@ NANO_INLINE_VAR(detail::count_if_fn, count_if)
 namespace detail {
 
 struct count_fn {
-private:
-    template <typename ValueType>
-    struct equal_to_pred {
-        const ValueType& val;
-
-        template <typename T>
-        constexpr bool operator()(const T& t) const
-        {
-            return t == val;
-        }
-    };
-
-public:
     template <typename I, typename S, typename T, typename Proj = identity>
     constexpr std::enable_if_t<
         InputIterator<I> && Sentinel<S, I> &&
@@ -85,7 +72,7 @@ public:
         iter_difference_t<I>>
     operator()(I first, S last, const T& value, Proj proj = Proj{}) const
     {
-        const auto pred = equal_to_pred<T>{value};
+        const auto pred = [&value] (const auto& t) { return t == value; };
         return count_if_fn::impl(std::move(first), std::move(last),
                                  pred, proj);
     }
@@ -98,7 +85,7 @@ public:
         iter_difference_t<iterator_t<Rng>>>
     operator()(Rng&& rng, const T& value, Proj proj = Proj{}) const
     {
-        const auto pred = equal_to_pred<T>{value};
+        const auto pred = [&value] (const auto& t) { return t == value; };
         return count_if_fn::impl(nano::begin(rng), nano::end(rng),
                                  pred, proj);
     }

--- a/include/nanorange/algorithm/find.hpp
+++ b/include/nanorange/algorithm/find.hpp
@@ -60,19 +60,6 @@ NANO_INLINE_VAR(detail::find_if_fn, find_if)
 namespace detail {
 
 struct find_fn {
-private:
-    template <typename ValueType>
-    struct equal_to_pred {
-        const ValueType& val;
-
-        template <typename T>
-        constexpr bool operator()(const T& t) const
-        {
-            return t == val;
-        }
-    };
-
-public:
     template <typename I, typename S, typename T, typename Proj = identity>
     constexpr std::enable_if_t<
         InputIterator<I> && Sentinel<S, I> &&
@@ -80,7 +67,7 @@ public:
         I>
     operator()(I first, S last, const T& value, Proj proj = Proj{}) const
     {
-        const equal_to_pred<T> pred{value};
+        const auto pred = [&value] (const auto& t) { return t == value; };
         return find_if_fn::impl(std::move(first), std::move(last), pred, proj);
     }
 
@@ -92,7 +79,7 @@ public:
         safe_iterator_t<Rng>>
     operator()(Rng&& rng, const T& value, Proj proj = Proj{}) const
     {
-        const equal_to_pred<T> pred{value};
+        const auto pred = [&value] (const auto& t) { return t == value; };
         return find_if_fn::impl(nano::begin(rng), nano::end(rng), pred, proj);
     }
 };

--- a/include/nanorange/algorithm/is_permutation.hpp
+++ b/include/nanorange/algorithm/is_permutation.hpp
@@ -17,27 +17,14 @@ namespace detail {
 
 struct is_permutation_fn {
 private:
-    template <typename Pred, typename Val>
-    struct comparator
-    {
-        Pred& pred;
-        const Val& val;
-
-        template <typename T>
-        constexpr bool operator()(const T& t) const
-        {
-            return nano::invoke(pred, t, val);
-        }
-    };
-
     template <typename I1, typename S1, typename I2, typename S2, typename Pred,
               typename Proj1, typename Proj2>
     static constexpr bool process_tail(I1 first1, S1 last1, I2 first2, S2 last2,
                                        Pred& pred, Proj1& proj1, Proj2& proj2)
     {
         for (auto it = first1; it != last1; ++it) {
-            comparator<Pred, decltype(nano::invoke(proj1, *it))>
-                comp{pred, nano::invoke(proj1, *it)};
+            const auto comp = [&pred, val = nano::invoke(proj1, *it)]
+                    (const auto& t) { return nano::invoke(pred, t, val); };
 
             // Check whether we have already seen this value
             if (any_of_fn::impl(first1, it, comp, proj1)) {
@@ -135,7 +122,7 @@ public:
     operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {
-        if /*constexpr*/ (SizedSentinel<S1, I1> && SizedSentinel<S2, I2>) {
+        if constexpr (SizedSentinel<S1, I1> && SizedSentinel<S2, I2>) {
             if (nano::distance(first1, last1) != nano::distance(first2, last2)) {
                 return false;
             }

--- a/include/nanorange/algorithm/nth_element.hpp
+++ b/include/nanorange/algorithm/nth_element.hpp
@@ -31,25 +31,15 @@ namespace detail {
 
 struct nth_element_fn {
 private:
-    template <typename Comp, typename Proj>
-    struct invoke_helper {
-        Comp& comp;
-        Proj& proj;
-
-        template <typename T, typename U>
-        constexpr bool operator()(T&& t, U&& u) const
-        {
-            return nano::invoke(comp, nano::invoke(proj, std::forward<T>(t)),
-                                nano::invoke(proj, std::forward<U>(u)));
-        }
-    };
-
     template <typename I, typename Comp, typename Proj>
     static constexpr void impl(I first, I nth, I last, Comp& comp, Proj& proj)
     {
         constexpr iter_difference_t<I> limit = 7;
 
-        const auto pred = invoke_helper<Comp, Proj>{comp, proj};
+        const auto pred = [&comp, &proj] (auto&& t, auto&& u) {
+            return nano::invoke(comp, nano::invoke(proj, std::forward<decltype(t)>(t)),
+                                nano::invoke(proj, std::forward<decltype(u)>(u)));
+        };
 
         I end = last;
 
@@ -220,7 +210,10 @@ private:
     template <typename I, typename Comp, typename Proj>
     static constexpr unsigned sort3(I x, I y, I z, Comp& comp, Proj& proj)
     {
-        auto pred = invoke_helper<Comp, Proj>{comp, proj};
+        const auto pred = [&comp, &proj] (auto&& t, auto&& u) {
+            return nano::invoke(comp, nano::invoke(proj, std::forward<decltype(t)>(t)),
+                                nano::invoke(proj, std::forward<decltype(u)>(u)));
+        };
 
         if (!pred(*y, *x)) {      // if x <= y
             if (!pred(*z, *y)) {  // if y <= z

--- a/include/nanorange/detail/macros.hpp
+++ b/include/nanorange/detail/macros.hpp
@@ -9,14 +9,6 @@
 
 #include <ciso646>
 
-#if (__cplusplus >= 201703) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define NANO_HAVE_CPP17
-#endif
-
-#if defined(NANO_HAVE_CPP17) || defined(__cpp_inline_variables)
-#define NANO_HAVE_INLINE_VARS
-#endif
-
 #ifdef NANORANGE_NO_DEPRECATION_WARNINGS
 #define NANO_DEPRECATED
 #define NANO_DEPRECATED_FOR(x)
@@ -25,17 +17,7 @@
 #define NANO_DEPRECATED_FOR(x) [[deprecated(x)]]
 #endif
 
-#ifdef NANO_HAVE_CPP17
-#define NANO_NODISCARD [[nodiscard]]
-#else
-#define NANO_NODISCARD
-#endif
-
-#if defined(NANO_HAVE_CPP17) || defined(__cpp_deduction_guides)
-#define NANO_HAVE_DEDUCTION_GUIDES
-#endif
-
-#define NANO_CONCEPT constexpr bool
+#define NANO_CONCEPT inline constexpr bool
 
 #define NANO_BEGIN_NAMESPACE                                                   \
     \
@@ -49,38 +31,10 @@ inline namespace ranges                                                        \
     }                                                                          \
     }
 
-#ifdef NANO_HAVE_INLINE_VARS
 #define NANO_INLINE_VAR(type, name)                                            \
     inline namespace function_objects {                                        \
     inline constexpr type name{};                                              \
     }
-#define NANO_INLINE_VARIABLE inline
-#else
-#define NANO_INLINE_VAR(type, name)                                            \
-    inline namespace function_objects {                                        \
-    inline namespace {                                                         \
-    constexpr const auto& name =                                               \
-        ::nano::ranges::detail::static_const_<type>::value;                    \
-    }                                                                          \
-    }
-#define NANO_INLINE_VARIABLE
-#endif
-
-NANO_BEGIN_NAMESPACE
-
-namespace detail {
-
-template <typename T>
-struct static_const_ {
-    static constexpr T value{};
-};
-
-template <typename T>
-constexpr T static_const_<T>::value;
-
-} // namespace detail
-
-NANO_END_NAMESPACE
 
 #if defined(_LIBCPP_VERSION)
 #define NANO_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_NAMESPACE_STD

--- a/include/nanorange/detail/memory/temporary_vector.hpp
+++ b/include/nanorange/detail/memory/temporary_vector.hpp
@@ -57,7 +57,7 @@ public:
 
     std::size_t size() const { return end_ - start_.get(); }
     std::size_t capacity() const { return end_cap_ - start_.get(); }
-    NANO_NODISCARD bool empty() const { return size() == 0; }
+    [[nodiscard]] bool empty() const { return size() == 0; }
 
     void push_back(const T& elem) { emplace_back(elem); }
     void push_back(T&& elem) { emplace_back(std::move(elem)); }

--- a/include/nanorange/detail/ranges/begin_end.hpp
+++ b/include/nanorange/detail/ranges/begin_end.hpp
@@ -10,9 +10,7 @@
 #include <nanorange/detail/functional/decay_copy.hpp>
 #include <nanorange/detail/iterator/concepts.hpp>
 
-#ifdef NANO_HAVE_CPP17
 #include <string_view>
-#endif
 
 NANO_BEGIN_NAMESPACE
 
@@ -41,7 +39,6 @@ private:
 
     // Specialisation for rvalue string_views in C++17, as we can't add
     // functions to namespace std
-#ifdef NANO_HAVE_CPP17
     template <typename C, typename T>
     static constexpr auto
     impl(std::basic_string_view<C, T> sv, priority_tag<2>) noexcept
@@ -49,7 +46,6 @@ private:
     {
         return sv.begin();
     }
-#endif
 
     template <typename T>
     static constexpr auto
@@ -106,7 +102,6 @@ private:
         return t + N;
     }
 
-#ifdef NANO_HAVE_CPP17
     template <typename C, typename T>
     static constexpr auto
     impl(std::basic_string_view<C, T> sv, priority_tag<2>) noexcept
@@ -114,7 +109,6 @@ private:
     {
         return sv.end();
     }
-#endif
 
     template <typename T,
               typename S = decltype(decay_copy(std::declval<T&>().end())),

--- a/include/nanorange/iterator/default_sentinel.hpp
+++ b/include/nanorange/iterator/default_sentinel.hpp
@@ -13,7 +13,7 @@ NANO_BEGIN_NAMESPACE
 
 struct default_sentinel_t {};
 
-NANO_INLINE_VARIABLE constexpr default_sentinel_t default_sentinel{};
+inline constexpr default_sentinel_t default_sentinel{};
 
 NANO_END_NAMESPACE
 

--- a/include/nanorange/iterator/unreachable.hpp
+++ b/include/nanorange/iterator/unreachable.hpp
@@ -43,7 +43,7 @@ struct unreachable_sentinel_t {
     }
 };
 
-NANO_INLINE_VARIABLE constexpr unreachable_sentinel_t unreachable_sentinel{};
+inline constexpr unreachable_sentinel_t unreachable_sentinel{};
 
 NANO_END_NAMESPACE
 

--- a/include/nanorange/view/interface.hpp
+++ b/include/nanorange/view/interface.hpp
@@ -51,14 +51,14 @@ private:
 
 public:
     template <typename R = D>
-    NANO_NODISCARD constexpr auto empty()
+    [[nodiscard]] constexpr auto empty()
         -> std::enable_if_t<ForwardRange<R>, bool>
     {
         return ranges::begin(derived()) == ranges::end(derived());
     }
 
     template <typename R = D>
-    NANO_NODISCARD constexpr auto empty() const
+    [[nodiscard]] constexpr auto empty() const
         -> std::enable_if_t<ForwardRange<const R>, bool>
     {
         return ranges::begin(derived()) == ranges::end(derived());

--- a/include/nanorange/view/subrange.hpp
+++ b/include/nanorange/view/subrange.hpp
@@ -42,38 +42,6 @@ using subrange_::subrange;
 
 namespace detail {
 
-// libstdc++ < 7 does not have a SFINAE-friendly std::tuple_size,
-// meaning that doing virtually anything with it is a hard error, including
-// testing the PairLike concept below. As a workaround, we'll define our own
-// tuple_size (only for std::tuple and std::pair) if we're using libstdc++ v5 or
-// v6.
-//
-// FIXME: Do this better.
-//
-// Note:
-// __GNUC__ tells us we're using GCC or Clang
-// !_LIBCPP_VERSION tells us we're not using libc++
-// !_GLIBCXX_RELEASE tells us we're not using libstdc++ >= 7, which is when this
-// symbol was added
-#if defined(__GNUC__) && !defined(_LIBCPP_VERSION) && !defined(_GLIBCXX_RELEASE)
-template <typename>
-struct sfinae_tuple_size {};
-
-template <typename T>
-struct sfinae_tuple_size<const T>
-    : sfinae_tuple_size<T> {};
-
-template <typename T, typename U>
-struct sfinae_tuple_size<std::pair<T, U>>
-    : std::integral_constant<std::size_t, 2> {};
-
-template <typename... Args>
-struct sfinae_tuple_size<std::tuple<Args...>>
-    : std::integral_constant<std::size_t, sizeof...(Args)> {};
-#else
-template <typename T>
-using sfinae_tuple_size = std::tuple_size<T>;
-#endif
 
 struct PairLike_req {
     template <std::size_t I, typename T>
@@ -82,7 +50,7 @@ struct PairLike_req {
 
     template <typename T>
     auto requires_(T t) -> decltype(
-            requires_expr<DerivedFrom<sfinae_tuple_size<T>, std::integral_constant<std::size_t, 2>>>{},
+            requires_expr<DerivedFrom<std::tuple_size<T>, std::integral_constant<std::size_t, 2>>>{},
             std::declval<std::tuple_element_t<0, std::remove_const_t<T>>>(),
             std::declval<std::tuple_element_t<1, std::remove_const_t<T>>>(),
             this->test_func<0, T>(std::get<0>(t)),
@@ -93,7 +61,7 @@ template <typename T>
 auto PairLike_fn(long) -> std::false_type;
 
 template <typename T,
-          typename = typename sfinae_tuple_size<T>::type,
+          typename = typename std::tuple_size<T>::type,
           typename = std::enable_if_t<detail::requires_<detail::PairLike_req, T>>>
 auto PairLike_fn(int) -> std::true_type;
 

--- a/include/nanorange/view/subrange.hpp
+++ b/include/nanorange/view/subrange.hpp
@@ -274,7 +274,7 @@ public:
 
     constexpr S end() const { return data_.end_; }
 
-    NANO_NODISCARD constexpr bool empty() const
+    [[nodiscard]] constexpr bool empty() const
     {
         return data_.begin_ == data_.end_;
     }
@@ -287,7 +287,7 @@ public:
         return do_size(SS_t{});
     }
 
-    NANO_NODISCARD constexpr subrange next(iter_difference_t<I> n = 1) const
+    [[nodiscard]] constexpr subrange next(iter_difference_t<I> n = 1) const
     {
         auto tmp = *this;
         tmp.advance(n);
@@ -295,7 +295,7 @@ public:
     }
 
     template <typename II = I>
-    NANO_NODISCARD constexpr auto prev(iter_difference_t<I> n = 1) const
+    [[nodiscard]] constexpr auto prev(iter_difference_t<I> n = 1) const
         -> std::enable_if_t<BidirectionalIterator<II>, subrange>
     {
         auto tmp = *this;
@@ -315,8 +315,6 @@ public:
     friend constexpr S end(subrange&& r) { return r.end(); }
 };
 
-#ifdef NANO_HAVE_DEDUCTION_GUIDES
-
 template <typename I, typename S, std::enable_if_t<Iterator<I> && Sentinel<S, I>, int> = 0>
 subrange(I, S, iter_difference_t<I>) -> subrange<I, S, subrange_kind::sized>;
 
@@ -335,8 +333,6 @@ subrange(R&&) ->
 template <typename R, std::enable_if_t<detail::ForwardingRange<R>, int> = 0>
 subrange(R&&, iter_difference_t<iterator_t<R>>) ->
     subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>;
-
-#endif
 
 } // namespace subrange_
 

--- a/include/nanorange/view/subrange.hpp
+++ b/include/nanorange/view/subrange.hpp
@@ -289,30 +289,15 @@ subrange(R&&, iter_difference_t<iterator_t<R>>) ->
 
 } // namespace subrange_
 
-namespace detail {
-
-template <typename I, typename S, subrange_kind K>
-constexpr I subrange_get_helper(std::integral_constant<std::size_t, 0>,
-                                const subrange<I, S, K>& s)
-{
-    return s.begin();
-}
-
-template <typename I, typename S, subrange_kind K>
-constexpr S subrange_get_helper(std::integral_constant<std::size_t, 1>,
-                                const subrange<I, S, K>& s)
-{
-    return s.end();
-}
-
-} // namespace detail
-
-template <std::size_t N, typename I, typename S, subrange_kind K>
+template <std::size_t N, typename I, typename S, subrange_kind K,
+          std::enable_if_t<(N < 2), int> = 0>
 constexpr auto get(const subrange<I, S, K>& r)
-    -> std::enable_if_t<N < 2,
-           decltype(detail::subrange_get_helper(std::integral_constant<size_t, N>{}, r))>
 {
-    return detail::subrange_get_helper(std::integral_constant<size_t, N>{}, r);
+    if constexpr (N == 0) {
+        return r.begin();
+    } else {
+        return r.end();
+    }
 }
 
 // Extensions for C++14 compilers without CTAD

--- a/include/nanorange/view/subrange.hpp
+++ b/include/nanorange/view/subrange.hpp
@@ -268,6 +268,12 @@ public:
     friend constexpr S end(subrange&& r) { return r.end(); }
 };
 
+#ifdef _MSC_VER
+// FIXME: Extra deduction guide because MSVC can't use the (constrained) implicit one
+template <typename I, typename S, std::enable_if_t<Iterator<I> && Sentinel<S, I>, int> = 0>
+subrange(I, S) -> subrange<I, S>;
+#endif
+
 template <typename I, typename S, std::enable_if_t<Iterator<I> && Sentinel<S, I>, int> = 0>
 subrange(I, S, iter_difference_t<I>) -> subrange<I, S, subrange_kind::sized>;
 

--- a/include/nanorange/view/subrange.hpp
+++ b/include/nanorange/view/subrange.hpp
@@ -300,49 +300,6 @@ constexpr auto get(const subrange<I, S, K>& r)
     }
 }
 
-// Extensions for C++14 compilers without CTAD
-// These basically replicate the subrange constructors above
-
-template <typename I, typename S>
-constexpr auto make_subrange(I i, S s)
-    -> std::enable_if_t<Iterator<I> && Sentinel<S, I>,
-                        decltype(subrange<I, S>{std::move(i), std::move(s)})>
-{
-    return {std::move(i), std::move(s)};
-}
-
-template <typename I, typename S>
-constexpr auto make_subrange(I i, S s, iter_difference_t<I> n)
-    -> std::enable_if_t<Iterator<I> && Sentinel<S, I>,
-                        decltype(subrange<I, S>{std::move(i), std::move(s), n})>
-{
-    return {std::move(i), std::move(s), n};
-}
-
-template <typename R>
-constexpr auto make_subrange(R&& r)
-    -> std::enable_if_t<detail::ForwardingRange<R> && !SizedRange<R>,
-                        subrange<iterator_t<R>, sentinel_t<R>>>
-{
-    return {std::forward<R>(r)};
-}
-
-template <typename R>
-constexpr auto make_subrange(R&& r)
-    -> std::enable_if_t<detail::ForwardingRange<R> && SizedRange<R>,
-                        subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>>
-{
-    return {std::forward<R>(r)};
-}
-
-template <typename R>
-constexpr auto make_subrange(R&& r, iter_difference_t<R> n)
--> std::enable_if_t<detail::ForwardingRange<R>,
-        subrange<iterator_t<R>, sentinel_t<R>, subrange_kind::sized>>
-{
-    return {std::forward<R>(r), n};
-}
-
 template <typename R>
 using safe_subrange_t =
     std::enable_if_t<detail::ForwardingRange<R>, subrange<iterator_t<R>>>;

--- a/manifest
+++ b/manifest
@@ -2,12 +2,12 @@
 
 name: nanorange
 version: 0.1.0-a.0.z
-summary: std::ranges implementation for C++14+
+summary: std::ranges implementation for C++17
 license: BSL ; Boost software license
 url: https://github.com/tcbrindle/NanoRange
 depends: * build2 >= 0.8.0-
-requires: c++14
-requires: msvc_15u7 | clang_3.8 | gcc_5.4
+requires: c++17
+requires: msvc_15u7 | clang_4.0 | gcc_7.1
 build-exclude: *-msvc_14* ; MSVC version too old
 build-exclude: linux-clang_5.0 ; Error in libstdc++ make_integer_sequence
 build-exclude: linux-clang_6.0 ; Same

--- a/test/algorithm/copy_backward.cpp
+++ b/test/algorithm/copy_backward.cpp
@@ -55,7 +55,7 @@ namespace {
 		CHECK(result.out == target + 4);
 		CHECK(std::count(target, target + 4, 0) == 4);
 		auto l2 = {1, 2, 3, 4};
-		CHECK(ranges::equal(ranges::make_subrange(target + 4, target + 8), std::move(l2)));
+		CHECK(ranges::equal(ranges::subrange(target + 4, target + 8), std::move(l2)));
 	}
 }
 

--- a/test/algorithm/count.cpp
+++ b/test/algorithm/count.cpp
@@ -25,7 +25,6 @@ struct S {
 TEST_CASE("alg.count")
 {
 	using namespace nano;
-	using nano::make_subrange;
 
 	int ia[] = {0, 1, 2, 2, 0, 1, 2, 3};
 	constexpr unsigned cia = size(ia);
@@ -37,11 +36,11 @@ TEST_CASE("alg.count")
 	CHECK(count(input_iterator<const int*>(ia),
 				sentinel<const int*>(ia), 2) == 0);
 
-	CHECK(count(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count(subrange(input_iterator<const int*>(ia),
 					  sentinel<const int*>(ia + cia)), 2) == 3);
-	CHECK(count(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count(subrange(input_iterator<const int*>(ia),
 					  sentinel<const int*>(ia + cia)), 7) == 0);
-	CHECK(count(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count(subrange(input_iterator<const int*>(ia),
 					  sentinel<const int*>(ia)), 2) == 0);
 
 	S sa[] = {{0}, {1}, {2}, {2}, {0}, {1}, {2}, {3}};
@@ -54,11 +53,11 @@ TEST_CASE("alg.count")
 	CHECK(count(input_iterator<const S*>(sa),
 				sentinel<const S*>(sa), 2, &S::i) == 0);
 
-	CHECK(count(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count(subrange(input_iterator<const S*>(sa),
 					  sentinel<const S*>(sa + csa)), 2, &S::i) == 3);
-	CHECK(count(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count(subrange(input_iterator<const S*>(sa),
 					  sentinel<const S*>(sa + csa)), 7, &S::i) == 0);
-	CHECK(count(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count(subrange(input_iterator<const S*>(sa),
 					  sentinel<const S*>(sa)), 2, &S::i) == 0);
 
 	{

--- a/test/algorithm/count_if.cpp
+++ b/test/algorithm/count_if.cpp
@@ -31,7 +31,7 @@ struct T {
 TEST_CASE("alg.count_if")
 {
 	using namespace nano;
-	using nano::make_subrange;
+	using nano::subrange;
 	auto equals = [](auto&& i){
 	  return [i = std::forward<decltype(i)>(i)](const auto& j) {
 		return i == j;
@@ -48,11 +48,11 @@ TEST_CASE("alg.count_if")
 	CHECK(count_if(input_iterator<const int*>(ia),
 				   sentinel<const int*>(ia), equals(2)) == 0);
 
-	CHECK(count_if(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count_if(subrange(input_iterator<const int*>(ia),
 						 sentinel<const int*>(ia + cia)), equals(2)) == 3);
-	CHECK(count_if(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count_if(subrange(input_iterator<const int*>(ia),
 						 sentinel<const int*>(ia + cia)), equals(7)) == 0);
-	CHECK(count_if(make_subrange(input_iterator<const int*>(ia),
+	CHECK(count_if(subrange(input_iterator<const int*>(ia),
 						 sentinel<const int*>(ia)), equals(2)) == 0);
 
 	S sa[] = {{0}, {1}, {2}, {2}, {0}, {1}, {2}, {3}};
@@ -65,11 +65,11 @@ TEST_CASE("alg.count_if")
 	CHECK(count_if(input_iterator<const S*>(sa),
 				   sentinel<const S*>(sa), equals(2), &S::i) == 0);
 
-	CHECK(count_if(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count_if(subrange(input_iterator<const S*>(sa),
 						 sentinel<const S*>(sa + csa)), equals(2), &S::i) == 3);
-	CHECK(count_if(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count_if(subrange(input_iterator<const S*>(sa),
 						 sentinel<const S*>(sa + csa)), equals(7), &S::i) == 0);
-	CHECK(count_if(make_subrange(input_iterator<const S*>(sa),
+	CHECK(count_if(subrange(input_iterator<const S*>(sa),
 						 sentinel<const S*>(sa)), equals(2), &S::i) == 0);
 
 	T ta[] = {{true}, {false}, {true}, {false}, {false}, {true}, {false}, {false}, {true}, {false}};
@@ -77,9 +77,9 @@ TEST_CASE("alg.count_if")
 				   sentinel<T*>(ta + size(ta)), &T::m) == 4);
 	CHECK(count_if(input_iterator<T*>(ta),
 				   sentinel<T*>(ta + size(ta)), &T::b) == 4);
-	CHECK(count_if(make_subrange(input_iterator<T*>(ta),
+	CHECK(count_if(subrange(input_iterator<T*>(ta),
 						 sentinel<T*>(ta + size(ta))), &T::m) == 4);
-	CHECK(count_if(make_subrange(input_iterator<T*>(ta),
+	CHECK(count_if(subrange(input_iterator<T*>(ta),
 						 sentinel<T*>(ta + size(ta))), &T::b) == 4);
 
 	{

--- a/test/algorithm/equal.cpp
+++ b/test/algorithm/equal.cpp
@@ -85,7 +85,6 @@ void test()
 void test_rng()
 {
 	using namespace ranges;
-	using nano::ranges::make_subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	constexpr unsigned s = size(ia);
@@ -97,41 +96,41 @@ void test_rng()
 												 sentinel<const int*>(ia+s)),
 							make_subrange(input_iterator<const int*>(ia),
 												 sentinel<const int*>(ia+s))));*/
-	CHECK(equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(equal(subrange(random_access_iterator<const int*>(ia),
 							  random_access_iterator<const int*>(ia + s)),
-				make_subrange(random_access_iterator<const int*>(ia),
+				subrange(random_access_iterator<const int*>(ia),
 							  random_access_iterator<const int*>(ia + s))));
 	/*CHECK(equal(make_subrange(random_access_iterator<const int*>(ia),
 												 sentinel<const int*>(ia+s)),
 							make_subrange(random_access_iterator<const int*>(ia),
 												 sentinel<const int*>(ia + s))));*/
-	CHECK(!equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!equal(subrange(input_iterator<const int*>(ia),
 							   input_iterator<const int*>(ia + s)),
 				 input_iterator<const int*>(ib)));
-	CHECK(!equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!equal(subrange(input_iterator<const int*>(ia),
 							   input_iterator<const int*>(ia + s)),
-				 make_subrange(input_iterator<const int*>(ib),
+				 subrange(input_iterator<const int*>(ib),
 							   input_iterator<const int*>(ib + s))));
-	CHECK(!equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!equal(subrange(random_access_iterator<const int*>(ia),
 							   random_access_iterator<const int*>(ia + s)),
-				 make_subrange(random_access_iterator<const int*>(ib),
+				 subrange(random_access_iterator<const int*>(ib),
 							   random_access_iterator<const int*>(ib + s))));
-	CHECK(!equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!equal(subrange(random_access_iterator<const int*>(ia),
 							   sentinel<const int*>(ia + s)),
-				 make_subrange(random_access_iterator<const int*>(ib),
+				 subrange(random_access_iterator<const int*>(ib),
 							   sentinel<const int*>(ib + s))));
-	CHECK(!equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!equal(subrange(input_iterator<const int*>(ia),
 							   sentinel<const int*>(ia + s)),
-				 make_subrange(input_iterator<const int*>(ia),
+				 subrange(input_iterator<const int*>(ia),
 							   sentinel<const int*>(ia + s - 1))));
-	CHECK(!equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!equal(subrange(random_access_iterator<const int*>(ia),
 							   random_access_iterator<const int*>(ia + s)),
-				 make_subrange(random_access_iterator<const int*>(ia),
+				 subrange(random_access_iterator<const int*>(ia),
 							   random_access_iterator<const int*>(
 									   ia + s - 1))));
-	CHECK(!equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!equal(subrange(random_access_iterator<const int*>(ia),
 							   sentinel<const int*>(ia + s)),
-				 make_subrange(random_access_iterator<const int*>(ia),
+				 subrange(random_access_iterator<const int*>(ia),
 							   sentinel<const int*>(ia + s - 1))));
 }
 
@@ -216,75 +215,75 @@ void test_pred()
 void test_rng_pred()
 {
 	using namespace nano::ranges;
-	using nano::ranges::make_subrange;
+	using nano::ranges::subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	constexpr unsigned s = size(ia);
 	int ib[s] = {0, 1, 2, 5, 4, 5};
-	CHECK(ranges::equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(ranges::equal(subrange(input_iterator<const int*>(ia),
 									  sentinel<const int*>(ia + s)),
 						input_iterator<const int*>(ia),
 						std::equal_to<int>()));
-	CHECK(ranges::equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(ranges::equal(subrange(input_iterator<const int*>(ia),
 									  sentinel<const int*>(ia + s)),
-						make_subrange(input_iterator<const int*>(ia),
+						subrange(input_iterator<const int*>(ia),
 									  sentinel<const int*>(ia + s)),
 						std::equal_to<int>()));
-	CHECK(ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									  random_access_iterator<const int*>(
 											  ia + s)),
-						make_subrange(random_access_iterator<const int*>(ia),
+						subrange(random_access_iterator<const int*>(ia),
 									  random_access_iterator<const int*>(
 											  ia + s)),
 						std::equal_to<int>()));
-	CHECK(ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									  sentinel<const int*>(ia + s)),
-						make_subrange(random_access_iterator<const int*>(ia),
+						subrange(random_access_iterator<const int*>(ia),
 									  sentinel<const int*>(ia + s)),
 						std::equal_to<int>()));
 
 	comparison_count = 0;
-	CHECK(!ranges::equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(input_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s)),
-						 make_subrange(input_iterator<const int*>(ia),
+						 subrange(input_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s - 1)),
 						 counting_equals<int>));
 	CHECK(comparison_count > 0);
 	comparison_count = 0;
-	CHECK(!ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									   random_access_iterator<const int*>(
 											   ia + s)),
-						 make_subrange(random_access_iterator<const int*>(ia),
+						 subrange(random_access_iterator<const int*>(ia),
 									   random_access_iterator<const int*>(
 											   ia + s - 1)),
 						 counting_equals<int>));
 	CHECK(comparison_count == 0);
 	comparison_count = 0;
-	CHECK(!ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s)),
-						 make_subrange(random_access_iterator<const int*>(ia),
+						 subrange(random_access_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s - 1)),
 						 counting_equals<int>));
 	CHECK(comparison_count > 0);
-	CHECK(!ranges::equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(input_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s)),
 						 input_iterator<const int*>(ib),
 						 std::equal_to<int>()));
-	CHECK(!ranges::equal(make_subrange(input_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(input_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s)),
-						 make_subrange(input_iterator<const int*>(ib),
+						 subrange(input_iterator<const int*>(ib),
 									   sentinel<const int*>(ib + s)),
 						 std::equal_to<int>()));
-	CHECK(!ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									   random_access_iterator<const int*>(
 											   ia + s)),
-						 make_subrange(random_access_iterator<const int*>(ib),
+						 subrange(random_access_iterator<const int*>(ib),
 									   random_access_iterator<const int*>(
 											   ib + s)),
 						 std::equal_to<int>()));
-	CHECK(!ranges::equal(make_subrange(random_access_iterator<const int*>(ia),
+	CHECK(!ranges::equal(subrange(random_access_iterator<const int*>(ia),
 									   sentinel<const int*>(ia + s)),
-						 make_subrange(random_access_iterator<const int*>(ib),
+						 subrange(random_access_iterator<const int*>(ib),
 									   sentinel<const int*>(ib + s)),
 						 std::equal_to<int>()));
 }

--- a/test/algorithm/equal_range.cpp
+++ b/test/algorithm/equal_range.cpp
@@ -60,7 +60,7 @@ test(Iter first, Sent last, const T& value, Proj proj = Proj{})
 		CHECK(value < ranges::invoke(proj, *j));
 
 	auto res = ranges::equal_range(
-			ranges::make_subrange(first, last), value, ranges::less<>{}, proj);
+			ranges::subrange(first, last), value, ranges::less<>{}, proj);
 	for (Iter j = first; j != res.begin(); ++j)
 		CHECK(ranges::invoke(proj, *j) < value);
 	for (Iter j = res.begin(); j != last; ++j)

--- a/test/algorithm/fill.cpp
+++ b/test/algorithm/fill.cpp
@@ -43,7 +43,7 @@ test_char() {
 	CHECK(ca[3] == 1);
 	CHECK(i == Iter(ca + 4));
 
-	auto rng = stl2::make_subrange(Iter(ca), Sent(ca + n));
+	auto rng = stl2::subrange(Iter(ca), Sent(ca + n));
 	i = stl2::fill(rng, char(2));
 	CHECK(ca[0] == 2);
 	CHECK(ca[1] == 2);
@@ -51,7 +51,7 @@ test_char() {
 	CHECK(ca[3] == 2);
 	CHECK(i == Iter(ca + 4));
 
-	auto j = stl2::fill(stl2::make_subrange(Iter(ca), Sent(ca + n)), char(3));
+	auto j = stl2::fill(stl2::subrange(Iter(ca), Sent(ca + n)), char(3));
 	CHECK(ca[0] == 3);
 	CHECK(ca[1] == 3);
 	CHECK(ca[2] == 3);
@@ -70,7 +70,7 @@ test_int() {
 	CHECK(ia[2] == 1);
 	CHECK(ia[3] == 1);
 
-	auto rng = stl2::make_subrange(Iter(ia), Sent(ia + n));
+	auto rng = stl2::subrange(Iter(ia), Sent(ia + n));
 	stl2::fill(rng, 2);
 	CHECK(ia[0] == 2);
 	CHECK(ia[2] == 2);

--- a/test/algorithm/fill_n.cpp
+++ b/test/algorithm/fill_n.cpp
@@ -56,7 +56,7 @@ test_char() {
 	CHECK(ca[3] == 1);
 	CHECK(i == Iter(ca + 4));
 
-	auto rng = stl2::make_subrange(Iter(ca), Sent(ca + n));
+	auto rng = stl2::subrange(Iter(ca), Sent(ca + n));
 	i = count_and_fill(rng, char(2));
 	CHECK(ca[0] == 2);
 	CHECK(ca[1] == 2);
@@ -64,7 +64,7 @@ test_char() {
 	CHECK(ca[3] == 2);
 	CHECK(i == Iter(ca + 4));
 
-	auto j = count_and_fill(stl2::make_subrange(Iter(ca), Sent(ca + n)), char(3));
+	auto j = count_and_fill(stl2::subrange(Iter(ca), Sent(ca + n)), char(3));
 	CHECK(ca[0] == 3);
 	CHECK(ca[1] == 3);
 	CHECK(ca[2] == 3);
@@ -83,7 +83,7 @@ test_int() {
 	CHECK(ia[2] == 1);
 	CHECK(ia[3] == 1);
 
-	auto rng = stl2::make_subrange(Iter(ia), Sent(ia + n));
+	auto rng = stl2::subrange(Iter(ia), Sent(ia + n));
 	count_and_fill(rng, 2);
 	CHECK(ia[0] == 2);
 	CHECK(ia[2] == 2);

--- a/test/algorithm/find_end.cpp
+++ b/test/algorithm/find_end.cpp
@@ -33,7 +33,6 @@ void
 test()
 {
 	using namespace nano;
-	using nano::make_subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 0, 1, 0};
 	constexpr unsigned sa = size(ia);
@@ -61,29 +60,29 @@ test()
 	CHECK(find_end(Iter1(ia), Sent1(ia + sa), Iter2(b), Sent2(b)).begin()
 				  == Iter1(ia + sa));
 	CHECK(find_end(Iter1(ia), Sent1(ia), Iter2(b), Sent2(b + 1)).begin() == Iter1(ia));
-    auto ir = make_subrange(Iter1(ia), Sent1(ia + sa));
-    CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia + sa - 1));
-    CHECK(find_end(ir, make_subrange(Iter2(c), Sent2(c + 2))).begin() == Iter1(ia + 18));
-    CHECK(find_end(ir, make_subrange(Iter2(d), Sent2(d + 3))).begin() == Iter1(ia + 15));
-    CHECK(find_end(ir, make_subrange(Iter2(e), Sent2(e + 4))).begin() == Iter1(ia + 11));
-    CHECK(find_end(ir, make_subrange(Iter2(f), Sent2(f + 5))).begin() == Iter1(ia + 6));
-    CHECK(find_end(ir, make_subrange(Iter2(g), Sent2(g + 6))).begin() == Iter1(ia));
-    CHECK(find_end(ir, make_subrange(Iter2(h), Sent2(h + 7))).begin() == Iter1(ia + sa));
-    CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b))).begin() == Iter1(ia + sa));
+    auto ir = subrange(Iter1(ia), Sent1(ia + sa));
+    CHECK(find_end(ir, subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia + sa - 1));
+    CHECK(find_end(ir, subrange(Iter2(c), Sent2(c + 2))).begin() == Iter1(ia + 18));
+    CHECK(find_end(ir, subrange(Iter2(d), Sent2(d + 3))).begin() == Iter1(ia + 15));
+    CHECK(find_end(ir, subrange(Iter2(e), Sent2(e + 4))).begin() == Iter1(ia + 11));
+    CHECK(find_end(ir, subrange(Iter2(f), Sent2(f + 5))).begin() == Iter1(ia + 6));
+    CHECK(find_end(ir, subrange(Iter2(g), Sent2(g + 6))).begin() == Iter1(ia));
+    CHECK(find_end(ir, subrange(Iter2(h), Sent2(h + 7))).begin() == Iter1(ia + sa));
+    CHECK(find_end(ir, subrange(Iter2(b), Sent2(b))).begin() == Iter1(ia + sa));
 
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia + sa - 1));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(c), Sent2(c + 2))).begin() == Iter1(ia + 18));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(d), Sent2(d + 3))).begin() == Iter1(ia + 15));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(e), Sent2(e + 4))).begin() == Iter1(ia + 11));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(f), Sent2(f + 5))).begin() == Iter1(ia + 6));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(g), Sent2(g + 6))).begin() == Iter1(ia));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(h), Sent2(h + 7))).begin() == Iter1(ia + sa));
-    CHECK(find_end(std::move(ir), make_subrange(Iter2(b), Sent2(b))).begin() == Iter1(ia + sa));
+    CHECK(find_end(std::move(ir), subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia + sa - 1));
+    CHECK(find_end(std::move(ir), subrange(Iter2(c), Sent2(c + 2))).begin() == Iter1(ia + 18));
+    CHECK(find_end(std::move(ir), subrange(Iter2(d), Sent2(d + 3))).begin() == Iter1(ia + 15));
+    CHECK(find_end(std::move(ir), subrange(Iter2(e), Sent2(e + 4))).begin() == Iter1(ia + 11));
+    CHECK(find_end(std::move(ir), subrange(Iter2(f), Sent2(f + 5))).begin() == Iter1(ia + 6));
+    CHECK(find_end(std::move(ir), subrange(Iter2(g), Sent2(g + 6))).begin() == Iter1(ia));
+    CHECK(find_end(std::move(ir), subrange(Iter2(h), Sent2(h + 7))).begin() == Iter1(ia + sa));
+    CHECK(find_end(std::move(ir), subrange(Iter2(b), Sent2(b))).begin() == Iter1(ia + sa));
 
-	auto er = make_subrange(Iter1(ia), Sent1(ia));
-	CHECK(find_end(er, make_subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia));
+	auto er = subrange(Iter1(ia), Sent1(ia));
+	CHECK(find_end(er, subrange(Iter2(b), Sent2(b + 1))).begin() == Iter1(ia));
 	CHECK(find_end(std::move(er),
-				   make_subrange(Iter2(b), Sent2(b + 1))).begin()
+				   subrange(Iter2(b), Sent2(b + 1))).begin()
 				  == Iter1(ia));
 }
 
@@ -105,7 +104,7 @@ void
 test_pred()
 {
 	using namespace nano;
-	using nano::make_subrange;
+	using nano::subrange;
 
 	int ia[] = {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 0, 1, 2, 3, 0, 1, 2, 0, 1, 0};
 	constexpr unsigned sa = size(ia);
@@ -154,42 +153,42 @@ test_pred()
 				  == Iter1(ia));
 	CHECK(count_equal::count == 0u);
 
-	auto ir = make_subrange(Iter1(ia), Sent1(ia + sa));
+	auto ir = subrange(Iter1(ia), Sent1(ia + sa));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b + 1)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(b), Sent2(b + 1)), count_equal()).begin()
 				  == Iter1(ia + sa - 1));
 	CHECK(count_equal::count <= 1 * (sa - 1 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(c), Sent2(c + 2)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(c), Sent2(c + 2)), count_equal()).begin()
 				  == Iter1(ia + 18));
 	CHECK(count_equal::count <= 2 * (sa - 2 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(d), Sent2(d + 3)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(d), Sent2(d + 3)), count_equal()).begin()
 				  == Iter1(ia + 15));
 	CHECK(count_equal::count <= 3 * (sa - 3 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(e), Sent2(e + 4)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(e), Sent2(e + 4)), count_equal()).begin()
 				  == Iter1(ia + 11));
 	CHECK(count_equal::count <= 4 * (sa - 4 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(f), Sent2(f + 5)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(f), Sent2(f + 5)), count_equal()).begin()
 				  == Iter1(ia + 6));
 	CHECK(count_equal::count <= 5 * (sa - 5 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(g), Sent2(g + 6)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(g), Sent2(g + 6)), count_equal()).begin()
 				  == Iter1(ia));
 	CHECK(count_equal::count <= 6 * (sa - 6 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(h), Sent2(h + 7)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(h), Sent2(h + 7)), count_equal()).begin()
 				  == Iter1(ia + sa));
 	CHECK(count_equal::count <= 7 * (sa - 7 + 1));
 	count_equal::count = 0;
-	CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b)), count_equal()).begin()
+	CHECK(find_end(ir, subrange(Iter2(b), Sent2(b)), count_equal()).begin()
 				  == Iter1(ia + sa));
 	CHECK(count_equal::count == 0u);
 	count_equal::count = 0;
-	auto er = make_subrange(Iter1(ia), Sent1(ia));
-	CHECK(find_end(er, make_subrange(Iter2(b), Sent2(b + 1)), count_equal()).begin()
+	auto er = subrange(Iter1(ia), Sent1(ia));
+	CHECK(find_end(er, subrange(Iter2(b), Sent2(b + 1)), count_equal()).begin()
 				  == Iter1(ia));
 	CHECK(count_equal::count == 0u);
 }
@@ -203,7 +202,7 @@ void
 test_proj()
 {
 	using namespace nano;
-	using nano::make_subrange;
+	using nano::subrange;
 
 	S ia[] = {{0}, {1}, {2}, {3}, {4}, {5}, {0}, {1}, {2}, {3}, {4}, {0}, {1}, {2}, {3}, {0}, {1}, {2}, {0}, {1}, {0}};
 	constexpr unsigned sa = size(ia);
@@ -233,25 +232,25 @@ test_proj()
 	CHECK(find_end(Iter1(ia), Sent1(ia), Iter2(b), Sent2(b + 1), equal_to<>(),
 				   &S::i_).begin() == Iter1(ia));
 
-	auto ir = make_subrange(Iter1(ia), Sent1(ia + sa));
-	CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b + 1)), equal_to<>(), &S::i_).begin()
+	auto ir = subrange(Iter1(ia), Sent1(ia + sa));
+	CHECK(find_end(ir, subrange(Iter2(b), Sent2(b + 1)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + sa - 1));
-	CHECK(find_end(ir, make_subrange(Iter2(c), Sent2(c + 2)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(c), Sent2(c + 2)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + 18));
-	CHECK(find_end(ir, make_subrange(Iter2(d), Sent2(d + 3)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(d), Sent2(d + 3)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + 15));
-	CHECK(find_end(ir, make_subrange(Iter2(e), Sent2(e + 4)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(e), Sent2(e + 4)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + 11));
-	CHECK(find_end(ir, make_subrange(Iter2(f), Sent2(f + 5)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(f), Sent2(f + 5)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + 6));
-	CHECK(find_end(ir, make_subrange(Iter2(g), Sent2(g + 6)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(g), Sent2(g + 6)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia));
-	CHECK(find_end(ir, make_subrange(Iter2(h), Sent2(h + 7)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(h), Sent2(h + 7)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + sa));
-	CHECK(find_end(ir, make_subrange(Iter2(b), Sent2(b)), equal_to<>(), &S::i_).begin()
+	CHECK(find_end(ir, subrange(Iter2(b), Sent2(b)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia + sa));
-	auto er = make_subrange(Iter1(ia), Sent1(ia));
-	CHECK(find_end(er, make_subrange(Iter2(b), Sent2(b + 1)), equal_to<>(), &S::i_).begin()
+	auto er = subrange(Iter1(ia), Sent1(ia));
+	CHECK(find_end(er, subrange(Iter2(b), Sent2(b + 1)), equal_to<>(), &S::i_).begin()
 				  == Iter1(ia));
 }
 

--- a/test/algorithm/find_first_of.cpp
+++ b/test/algorithm/find_first_of.cpp
@@ -99,51 +99,51 @@ void test_rng()
     int ib[] = {1, 3, 5, 7};
     static constexpr unsigned sb = size(ib);
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ib),
+            subrange(forward_iterator<const int*>(ib),
                        forward_iterator<const int*>(ib + sb))) ==
             input_iterator<const int*>(ia + 1));
-    CHECK(rng::find_first_of(make_subrange(input_iterator<const int*>(ia),
+    CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
                                         input_iterator<const int*>(ia + sa)),
-                             make_subrange(forward_iterator<const int*>(ib),
+                             subrange(forward_iterator<const int*>(ib),
                                         forward_iterator<const int*>(
                                                 ib + sb))) ==
             input_iterator<const int*>(ia + 1));
     int ic[] = {7};
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic + 1))) ==
             input_iterator<const int*>(ia + sa));
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic))) ==
             input_iterator<const int*>(ia + sa));
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic + 1))) ==
             input_iterator<const int*>(ia));
-    CHECK(rng::find_first_of(make_subrange(input_iterator<const int*>(ia),
+    CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
                                         input_iterator<const int*>(ia + sa)),
-                             make_subrange(forward_iterator<const int*>(ic),
+                             subrange(forward_iterator<const int*>(ic),
                                         forward_iterator<const int*>(
                                                 ic + 1))) ==
             input_iterator<const int*>(ia + sa));
-    CHECK(rng::find_first_of(make_subrange(input_iterator<const int*>(ia),
+    CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
                                         input_iterator<const int*>(ia + sa)),
-                             make_subrange(forward_iterator<const int*>(ic),
+                             subrange(forward_iterator<const int*>(ic),
                                         forward_iterator<const int*>(
                                                 ic))) ==
             input_iterator<const int*>(ia + sa));
-    CHECK(rng::find_first_of(make_subrange(input_iterator<const int*>(ia),
+    CHECK(rng::find_first_of(subrange(input_iterator<const int*>(ia),
                                         input_iterator<const int*>(ia)),
-                             make_subrange(forward_iterator<const int*>(ic),
+                             subrange(forward_iterator<const int*>(ic),
                                         forward_iterator<const int*>(
                                                 ic + 1))) ==
             input_iterator<const int*>(ia));
@@ -157,31 +157,31 @@ void test_rng_pred()
     int ib[] = {1, 3, 5, 7};
     static constexpr unsigned sb = size(ib);
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ib),
+            subrange(forward_iterator<const int*>(ib),
                        forward_iterator<const int*>(ib + sb)),
             std::equal_to<int>()) ==
             input_iterator<const int*>(ia + 1));
     int ic[] = {7};
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic + 1)),
             std::equal_to<int>()) ==
             input_iterator<const int*>(ia + sa));
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia + sa))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic)),
             std::equal_to<int>()) ==
             input_iterator<const int*>(ia + sa));
     CHECK(rng::find_first_of(
-            as_lvalue(make_subrange(input_iterator<const int*>(ia),
+            as_lvalue(subrange(input_iterator<const int*>(ia),
                                  input_iterator<const int*>(ia))),
-            make_subrange(forward_iterator<const int*>(ic),
+            subrange(forward_iterator<const int*>(ic),
                        forward_iterator<const int*>(ic + 1)),
             std::equal_to<int>()) ==
             input_iterator<const int*>(ia));
@@ -198,32 +198,32 @@ void test_rng_pred_proj()
     static constexpr unsigned sa = size(ia);
     S ib[] = {S{1}, S{3}, S{5}, S{7}};
     static constexpr unsigned sb = size(ib);
-    CHECK(rng::find_first_of(as_lvalue(make_subrange(input_iterator<const S*>(ia),
+    CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
                                                   input_iterator<const S*>(
                                                           ia + sa))),
-                             make_subrange(forward_iterator<const S*>(ib),
+                             subrange(forward_iterator<const S*>(ib),
                                         forward_iterator<const S*>(ib + sb)),
                              std::equal_to<int>(), &S::i, &S::i) ==
             input_iterator<const S*>(ia + 1));
     S ic[] = {S{7}};
-    CHECK(rng::find_first_of(as_lvalue(make_subrange(input_iterator<const S*>(ia),
+    CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
                                                   input_iterator<const S*>(
                                                           ia + sa))),
-                             make_subrange(forward_iterator<const S*>(ic),
+                             subrange(forward_iterator<const S*>(ic),
                                         forward_iterator<const S*>(ic + 1)),
                              std::equal_to<int>(), &S::i, &S::i) ==
             input_iterator<const S*>(ia + sa));
-    CHECK(rng::find_first_of(as_lvalue(make_subrange(input_iterator<const S*>(ia),
+    CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
                                                   input_iterator<const S*>(
                                                           ia + sa))),
-                             make_subrange(forward_iterator<const S*>(ic),
+                             subrange(forward_iterator<const S*>(ic),
                                         forward_iterator<const S*>(ic)),
                              std::equal_to<int>(), &S::i, &S::i) ==
             input_iterator<const S*>(ia + sa));
-    CHECK(rng::find_first_of(as_lvalue(make_subrange(input_iterator<const S*>(ia),
+    CHECK(rng::find_first_of(as_lvalue(subrange(input_iterator<const S*>(ia),
                                                   input_iterator<const S*>(
                                                           ia))),
-                             make_subrange(forward_iterator<const S*>(ic),
+                             subrange(forward_iterator<const S*>(ic),
                                         forward_iterator<const S*>(ic + 1)),
                              std::equal_to<int>(), &S::i, &S::i) ==
             input_iterator<const S*>(ia));

--- a/test/algorithm/for_each.cpp
+++ b/test/algorithm/for_each.cpp
@@ -50,7 +50,7 @@ TEST_CASE("alg.for_each")
 	CHECK(sum == 24);
 
 	sum = 0;
-	CHECK(stl2::for_each(stl2::make_subrange(v1.begin(), v1.end()), fun).in == v1.end());
+	CHECK(stl2::for_each(stl2::subrange(v1.begin(), v1.end()), fun).in == v1.end());
 	CHECK(sum == 12);
 
 	{

--- a/test/algorithm/generate.cpp
+++ b/test/algorithm/generate.cpp
@@ -54,7 +54,7 @@ test() {
 	CHECK(res1 == Iter(ia + n));
 	CHECK(f.i_ == 5);
 
-	auto rng = stl2::make_subrange(Iter(ia), Sent(ia + n));
+	auto rng = stl2::subrange(Iter(ia), Sent(ia + n));
 	auto res2 = stl2::generate(rng, std::ref(f));
 	CHECK(ia[0] == 5);
 	CHECK(ia[1] == 6);
@@ -75,7 +75,7 @@ test() {
 void test2() {
 	// Test stl2::generate with a genuine output range
 	std::vector<int> v;
-	auto rng = stl2::make_subrange(
+	auto rng = stl2::subrange(
 		stl2::make_counted_iterator(stl2::back_inserter(v), 5),
 		stl2::default_sentinel);
 	stl2::generate(rng, gen_test(1));

--- a/test/algorithm/inplace_merge.cpp
+++ b/test/algorithm/inplace_merge.cpp
@@ -65,7 +65,7 @@ test_one_rng(unsigned N, unsigned M)
 	std::sort(ia, ia + M);
 	std::sort(ia + M, ia + N);
 	auto res = stl2::inplace_merge(
-			::as_lvalue(nano::make_subrange(Iter(ia), Sent(ia + N))),
+			::as_lvalue(nano::subrange(Iter(ia), Sent(ia + N))),
 			Iter(ia + M));
 	CHECK(res == Iter(ia + N));
 	if (N > 0) {
@@ -78,7 +78,7 @@ test_one_rng(unsigned N, unsigned M)
 	std::sort(ia, ia + M);
 	std::sort(ia + M, ia + N);
 	auto res2 = stl2::inplace_merge(
-			nano::make_subrange(Iter(ia), Sent(ia + N)), Iter(ia + M));
+			nano::subrange(Iter(ia), Sent(ia + N)), Iter(ia + M));
 	CHECK(res2 == Iter(ia + N));
 	if (N > 0) {
 		CHECK(ia[0] == 0);

--- a/test/algorithm/is_partitioned.cpp
+++ b/test/algorithm/is_partitioned.cpp
@@ -79,31 +79,31 @@ test_range()
 {
 	{
 		const int ia[] = {1, 2, 3, 4, 5, 6};
-		CHECK(!stl2::is_partitioned(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(!stl2::is_partitioned(stl2::subrange(Iter(stl2::begin(ia)),
 														  Sent(stl2::end(ia))),
 									is_odd()));
 	}
 	{
 		const int ia[] = {1, 3, 5, 2, 4, 6};
-		CHECK(stl2::is_partitioned(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::is_partitioned(stl2::subrange(Iter(stl2::begin(ia)),
 														 Sent(stl2::end(ia))),
 								   is_odd()));
 	}
 	{
 		const int ia[] = {2, 4, 6, 1, 3, 5};
-		CHECK(!stl2::is_partitioned(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(!stl2::is_partitioned(stl2::subrange(Iter(stl2::begin(ia)),
 														  Sent(stl2::end(ia))),
 									is_odd()));
 	}
 	{
 		const int ia[] = {1, 3, 5, 2, 4, 6, 7};
-		CHECK(!stl2::is_partitioned(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(!stl2::is_partitioned(stl2::subrange(Iter(stl2::begin(ia)),
 														  Sent(stl2::end(ia))),
 									is_odd()));
 	}
 	{
 		const int ia[] = {1, 3, 5, 2, 4, 6, 7};
-		CHECK(stl2::is_partitioned(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::is_partitioned(stl2::subrange(Iter(stl2::begin(ia)),
 														 Sent(stl2::begin(ia))),
 								   is_odd()));
 	}

--- a/test/algorithm/is_permutation.cpp
+++ b/test/algorithm/is_permutation.cpp
@@ -758,21 +758,21 @@ TEST_CASE("alg.is_permutation")
 		const int ia[] = {0, 1, 2, 3, 0, 5, 6, 2, 4, 4};
 		const int ib[] = {4, 2, 3, 0, 1, 4, 0, 5, 6, 2};
 		const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
 								   forward_iterator<const int*>(ib)) == true);
 
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib),
+								   stl2::subrange(forward_iterator<const int*>(ib),
 								   sentinel<const int*>(ib + sa))) == true);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib + 1),
+								   stl2::subrange(forward_iterator<const int*>(ib + 1),
 								   sentinel<const int*>(ib + sa))) == false);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib),
+								   stl2::subrange(forward_iterator<const int*>(ib),
 								   sentinel<const int*>(ib + sa - 1))) == false);
 	}
 
@@ -781,24 +781,24 @@ TEST_CASE("alg.is_permutation")
 		const int ia[] = {0, 1, 2, 3, 0, 5, 6, 2, 4, 4};
 		const int ib[] = {4, 2, 3, 0, 1, 4, 0, 5, 6, 2};
 		const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
 								   forward_iterator<const int*>(ib),
 								   std::equal_to<int const>()) == true);
 
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib),
+								   stl2::subrange(forward_iterator<const int*>(ib),
 								   sentinel<const int*>(ib + sa)),
 								   std::equal_to<int const>()) == true);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib + 1),
+								   stl2::subrange(forward_iterator<const int*>(ib + 1),
 								   sentinel<const int*>(ib + sa)),
 								   std::equal_to<int const>()) == false);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const int*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const int*>(ia),
 								   sentinel<const int*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const int*>(ib),
+								   stl2::subrange(forward_iterator<const int*>(ib),
 								   sentinel<const int*>(ib + sa - 1)),
 								   std::equal_to<int const>()) == false);
 	}
@@ -810,14 +810,14 @@ TEST_CASE("alg.is_permutation")
 		const unsigned sa = sizeof(ia)/sizeof(ia[0]);
 		CHECK(stl2::is_permutation(ia, &ib[0], std::equal_to<int const>(), &S::i, &T::i) == true);
 		CHECK(stl2::is_permutation(ia, ib, std::equal_to<int const>(), &S::i, &T::i) == true);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const S*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const S*>(ia),
 								   sentinel<const S*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const T*>(ib + 1),
+								   stl2::subrange(forward_iterator<const T*>(ib + 1),
 								   sentinel<const T*>(ib + sa)),
 								   std::equal_to<int const>(), &S::i, &T::i) == false);
-		CHECK(stl2::is_permutation(stl2::make_subrange(forward_iterator<const S*>(ia),
+		CHECK(stl2::is_permutation(stl2::subrange(forward_iterator<const S*>(ia),
 								   sentinel<const S*>(ia + sa)),
-								   stl2::make_subrange(forward_iterator<const T*>(ib),
+								   stl2::subrange(forward_iterator<const T*>(ib),
 								   sentinel<const T*>(ib + sa - 1)),
 								   std::equal_to<int const>(), &S::i, &T::i) == false);
 	}

--- a/test/algorithm/is_sorted.cpp
+++ b/test/algorithm/is_sorted.cpp
@@ -59,7 +59,7 @@ struct range_call {
 	bool operator()(B&& b, E&& e, Args&& ... args)
 	{
 		return ranges::is_sorted(
-				ranges::make_subrange(begin_t{b}, sentinel_t{e}),
+				ranges::subrange(begin_t{b}, sentinel_t{e}),
 				std::forward<Args>(args)...);
 	}
 };

--- a/test/algorithm/is_sorted_until.cpp
+++ b/test/algorithm/is_sorted_until.cpp
@@ -60,11 +60,11 @@ struct range_call {
 	template <class B, class E, class... Args>
 	auto operator()(B&& It, E&& e, Args&& ... args)
 	-> decltype(stl2::is_sorted_until(
-			::as_lvalue(stl2::make_subrange(begin_t{It}, sentinel_t{e})),
+			::as_lvalue(stl2::subrange(begin_t{It}, sentinel_t{e})),
 			std::forward<Args>(args)...))
 	{
 		return stl2::is_sorted_until(
-				::as_lvalue(stl2::make_subrange(begin_t{It}, sentinel_t{e})),
+				::as_lvalue(stl2::subrange(begin_t{It}, sentinel_t{e})),
 				std::forward<Args>(args)...);
 	}
 };

--- a/test/algorithm/make_heap.cpp
+++ b/test/algorithm/make_heap.cpp
@@ -65,12 +65,12 @@ void test_3(int N)
 	for (int i = 0; i < N; ++i)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
-	CHECK(stl2::make_heap(::as_lvalue(stl2::make_subrange(ia, ia + N)))
+	CHECK(stl2::make_heap(::as_lvalue(stl2::subrange(ia, ia + N)))
 				  == ia + N);
 	CHECK(std::is_heap(ia, ia + N));
 
 	std::shuffle(ia, ia + N, gen);
-	CHECK(stl2::make_heap(stl2::make_subrange(ia, ia + N))
+	CHECK(stl2::make_heap(stl2::subrange(ia, ia + N))
 				  == ia + N);
 	CHECK(std::is_heap(ia, ia + N));
 
@@ -84,13 +84,13 @@ void test_4(int N)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
 	CHECK(stl2::make_heap(
-			::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + N))))
+			::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + N))))
 				  == ia + N);
 	CHECK(std::is_heap(ia, ia + N));
 
 	std::shuffle(ia, ia + N, gen);
 	CHECK(stl2::make_heap(
-			stl2::make_subrange(ia, sentinel<int*>(ia + N)))
+			stl2::subrange(ia, sentinel<int*>(ia + N)))
 				  == ia + N);
 	CHECK(std::is_heap(ia, ia + N));
 
@@ -126,12 +126,12 @@ void test_7(int N)
 	for (int i = 0; i < N; ++i)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
-	CHECK(stl2::make_heap(::as_lvalue(stl2::make_subrange(ia, ia + N)),
+	CHECK(stl2::make_heap(::as_lvalue(stl2::subrange(ia, ia + N)),
 						  std::greater<int>()) == ia + N);
 	CHECK(std::is_heap(ia, ia + N, std::greater<int>()));
 
 	std::shuffle(ia, ia + N, gen);
-	CHECK(stl2::make_heap(stl2::make_subrange(ia, ia + N),
+	CHECK(stl2::make_heap(stl2::subrange(ia, ia + N),
 						  std::greater<int>()) == ia + N);
 	CHECK(std::is_heap(ia, ia + N, std::greater<int>()));
 
@@ -145,12 +145,12 @@ void test_8(int N)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
 	CHECK(stl2::make_heap(
-			::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + N))),
+			::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + N))),
 			std::greater<int>()) == ia + N);
 	CHECK(std::is_heap(ia, ia + N, std::greater<int>()));
 
 	std::shuffle(ia, ia + N, gen);
-	CHECK(stl2::make_heap(stl2::make_subrange(ia, sentinel<int*>(ia + N)),
+	CHECK(stl2::make_heap(stl2::subrange(ia, sentinel<int*>(ia + N)),
 						  std::greater<int>()) == ia + N);
 	CHECK(std::is_heap(ia, ia + N, std::greater<int>()));
 

--- a/test/algorithm/max.cpp
+++ b/test/algorithm/max.cpp
@@ -40,7 +40,7 @@ void
 test_iter(Iter first, Sent last)
 {
 	assert(first != last);
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto v = stl2::max(rng);
 	for (Iter i = first; i != last; ++i)
 		CHECK(!(v < *i));
@@ -73,7 +73,7 @@ void
 test_iter_comp(Iter first, Sent last)
 {
 	assert(first != last);
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto comp = std::greater<int>();
 	auto v = stl2::max(rng, comp);
 	for (Iter i = first; i != last; ++i)

--- a/test/algorithm/max_element.cpp
+++ b/test/algorithm/max_element.cpp
@@ -45,7 +45,7 @@ test_iter(Iter first, Sent last)
 	else
 		CHECK(i == last);
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	i = stl2::max_element(rng);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j)
@@ -97,7 +97,7 @@ test_iter_comp(Iter first, Sent last)
 	else
 		CHECK(i == last);
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	i = stl2::max_element(rng, std::greater<int>());
 	if (first != last) {
 		for (Iter j = first; j != last; ++j)

--- a/test/algorithm/merge.cpp
+++ b/test/algorithm/merge.cpp
@@ -52,8 +52,8 @@ TEST_CASE("alg.merge")
 			ia[i] = 2 * i;
 		for(unsigned i = 0; i < N; ++i)
 			ib[i] = 2 * i + 1;
-		auto r0 = stl2::make_subrange(ia.get(), ia.get() + N);
-		auto r1 = stl2::make_subrange(ib.get(), ib.get() + N);
+		auto r0 = stl2::subrange(ia.get(), ia.get() + N);
+		auto r1 = stl2::subrange(ib.get(), ib.get() + N);
 		auto r = stl2::merge(r0, r1, ic.get());
 		CHECK(r.in1 == ia.get() + N);
 		CHECK(r.in2 == ib.get() + N);
@@ -73,8 +73,8 @@ TEST_CASE("alg.merge")
 			ia[i] = 2 * i;
 		for(unsigned i = 0; i < N; ++i)
 			ib[i] = 2 * i + 1;
-		auto r0 = stl2::make_subrange(ia.get(), ia.get() + N);
-		auto r1 = stl2::make_subrange(ib.get(), ib.get() + N);
+		auto r0 = stl2::subrange(ia.get(), ia.get() + N);
+		auto r1 = stl2::subrange(ib.get(), ib.get() + N);
 		auto r = stl2::merge(std::move(r0), std::move(r1), ic.get());
 		CHECK(r.in1 == ia.get() + N);
 		CHECK(r.in2 == ib.get() + N);

--- a/test/algorithm/min.cpp
+++ b/test/algorithm/min.cpp
@@ -39,7 +39,7 @@ void
 test_iter(Iter first, Sent last)
 {
 	REQUIRE(first != last);
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto v1 = stl2::min(rng);
 	for (Iter i = first; i != last; ++i)
 		CHECK(!(*i < v1));
@@ -72,7 +72,7 @@ void
 test_iter_comp(Iter first, Sent last)
 {
 	REQUIRE(first != last);
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto v = stl2::min(rng, std::greater<int>());
 	for (Iter i = first; i != last; ++i)
 		CHECK(!std::greater<int>()(*i, v));

--- a/test/algorithm/min_element.cpp
+++ b/test/algorithm/min_element.cpp
@@ -45,7 +45,7 @@ test_iter(Iter first, Sent last)
 	else
 		CHECK(i == last);
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	i = stl2::min_element(rng);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j)
@@ -97,7 +97,7 @@ test_iter_comp(Iter first, Sent last)
 	else
 		CHECK(i == last);
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	i = stl2::min_element(rng, std::greater<int>());
 	if (first != last) {
 		for (Iter j = first; j != last; ++j)

--- a/test/algorithm/minmax.cpp
+++ b/test/algorithm/minmax.cpp
@@ -40,7 +40,7 @@ void
 test_iter(Iter first, Sent last)
 {
 	assert(first != last);
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto res = stl2::minmax(rng);
 	for (Iter i = first; i != last; ++i) {
 		CHECK(!(*i < res.min));
@@ -77,7 +77,7 @@ test_iter_comp(Iter first, Sent last)
 	assert(first != last);
 	typedef std::greater<int> Compare;
 	Compare comp;
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	auto res = stl2::minmax(rng, comp);
 	for (Iter i = first; i != last; ++i) {
 		CHECK(!comp(*i, res.min));

--- a/test/algorithm/minmax_element.cpp
+++ b/test/algorithm/minmax_element.cpp
@@ -49,7 +49,7 @@ test_iter(Iter first, Sent last)
 		CHECK(p.max == last);
 	}
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	p = stl2::minmax_element(rng);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j) {
@@ -125,7 +125,7 @@ test_iter_comp(Iter first, Sent last)
 		CHECK(p.max == last);
 	}
 
-	auto rng = stl2::make_subrange(first, last);
+	auto rng = stl2::subrange(first, last);
 	p = stl2::minmax_element(rng, comp);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j) {

--- a/test/algorithm/mismatch.cpp
+++ b/test/algorithm/mismatch.cpp
@@ -27,7 +27,7 @@
 
 namespace ranges {
 	using namespace nano::ranges;
-	using nano::ranges::make_subrange;
+	using nano::ranges::subrange;
 }
 
 namespace {
@@ -71,14 +71,14 @@ void test_range()
 	constexpr unsigned sa = ranges::size(ia);
 	int ib[] = {0, 1, 2, 3, 0, 1, 2, 3};
 	using Pair = ranges::mismatch_result<Iter, Iter>;
-	auto rng1 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
+	auto rng1 = ranges::subrange(Iter(ia), Sent(ia + sa));
 	CHECK((ranges::mismatch(rng1, Iter(ib)) ==
 			Pair{Iter(ia + 3), Iter(ib + 3)}));
 	auto r1 = ranges::mismatch(std::move(rng1), Iter(ib));
 	CHECK(r1.in1 == Iter(ia + 3));
 	CHECK(r1.in2 == Iter(ib + 3));
-	auto rng2 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
-	auto rng3 = ranges::make_subrange(Iter(ib), Sent(ib + sa));
+	auto rng2 = ranges::subrange(Iter(ia), Sent(ia + sa));
+	auto rng3 = ranges::subrange(Iter(ib), Sent(ib + sa));
 	CHECK((ranges::mismatch(rng2, rng3) ==
 			Pair{Iter(ia + 3), Iter(ib + 3)}));
 	auto r2 = ranges::mismatch(std::move(rng2), std::move(rng3));
@@ -90,20 +90,20 @@ void test_range()
 	auto r4 = ranges::mismatch(std::move(rng2), rng3);
 	CHECK(r4.in1 == Iter(ia + 3));
 	CHECK(r4.in2 == Iter(ib + 3));
-	auto rng4 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
-	auto rng5 = ranges::make_subrange(Iter(ib), Sent(ib + 2));
+	auto rng4 = ranges::subrange(Iter(ia), Sent(ia + sa));
+	auto rng5 = ranges::subrange(Iter(ib), Sent(ib + 2));
 	CHECK((ranges::mismatch(rng4, rng5) ==
 			Pair{Iter(ia + 2), Iter(ib + 2)}));
 
-	auto rng6 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
+	auto rng6 = ranges::subrange(Iter(ia), Sent(ia + sa));
 	CHECK((ranges::mismatch(rng6, Iter(ib), std::equal_to<int>()) ==
 			Pair{Iter(ia + 3), Iter(ib + 3)}));
-	auto rng7 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
-	auto rng8 = ranges::make_subrange(Iter(ib), Sent(ib + sa));
+	auto rng7 = ranges::subrange(Iter(ia), Sent(ia + sa));
+	auto rng8 = ranges::subrange(Iter(ib), Sent(ib + sa));
 	CHECK((ranges::mismatch(rng7, rng8, std::equal_to<int>()) ==
 			Pair{Iter(ia + 3), Iter(ib + 3)}));
-	auto rng9 = ranges::make_subrange(Iter(ia), Sent(ia + sa));
-	auto rng10 = ranges::make_subrange(Iter(ib), Sent(ib + 2));
+	auto rng9 = ranges::subrange(Iter(ia), Sent(ia + sa));
+	auto rng10 = ranges::subrange(Iter(ib), Sent(ib + 2));
 	CHECK((ranges::mismatch(rng9, rng10, std::equal_to<int>()) ==
 			Pair{Iter(ia + 2), Iter(ib + 2)}));
 }

--- a/test/algorithm/move.cpp
+++ b/test/algorithm/move.cpp
@@ -53,7 +53,7 @@ test() {
 			ia[i] = i;
 		int ib[N] = {0};
 
-		auto r = stl2::move(as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + N))),
+		auto r = stl2::move(as_lvalue(stl2::subrange(InIter(ia), Sent(ia + N))),
 												  OutIter(ib));
 		CHECK(base(r.in) == ia + N);
 		CHECK(base(r.out) == ib + N);
@@ -92,7 +92,7 @@ test1() {
 			ia[i].reset(new int(i));
 		std::unique_ptr<int> ib[N];
 
-		auto r = stl2::move(as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + N))),
+		auto r = stl2::move(as_lvalue(stl2::subrange(InIter(ia), Sent(ia + N))),
 												  OutIter(ib));
 		CHECK(base(r.in) == ia + N);
 		CHECK(base(r.out) == ib + N);
@@ -103,7 +103,7 @@ test1() {
 
 		stl2::move(ib, ib + N, ia);
 
-		auto r2 = stl2::move(stl2::make_subrange(InIter(ia), Sent(ia + N)), OutIter(ib));
+		auto r2 = stl2::move(stl2::subrange(InIter(ia), Sent(ia + N)), OutIter(ib));
 		CHECK(base(r2.in) == ia + N);
 		CHECK(base(r2.out) == ib + N);
 		for (int i = 0; i < N; ++i) {

--- a/test/algorithm/move_backward.cpp
+++ b/test/algorithm/move_backward.cpp
@@ -53,7 +53,7 @@ test() {
 			ia[i] = i;
 		int ib[N] = {0};
 
-		auto r = stl2::move_backward(as_lvalue(stl2::make_subrange(InIter(ia), InIter(ia + N))),
+		auto r = stl2::move_backward(as_lvalue(stl2::subrange(InIter(ia), InIter(ia + N))),
 														   OutIter(ib + N));
 		CHECK(base(r.in) == ia + N);
 		CHECK(base(r.out) == ib);
@@ -92,7 +92,7 @@ test1() {
 			ia[i].reset(new int(i));
 		std::unique_ptr<int> ib[N];
 
-		auto r = stl2::move_backward(as_lvalue(stl2::make_subrange(InIter(ia), InIter(ia + N))),
+		auto r = stl2::move_backward(as_lvalue(stl2::subrange(InIter(ia), InIter(ia + N))),
 														   OutIter(ib + N));
 		CHECK(base(r.in) == ia + N);
 		CHECK(base(r.out) == ib);
@@ -103,7 +103,7 @@ test1() {
 
 		stl2::move_backward(ib, ib + N, ia + N);
 
-		auto r2 = stl2::move_backward(stl2::make_subrange(InIter(ia), InIter(ia + N)), OutIter(ib + N));
+		auto r2 = stl2::move_backward(stl2::subrange(InIter(ia), InIter(ia + N)), OutIter(ib + N));
 		CHECK(base(r2.in) == ia + N);
 		CHECK(base(r2.out) == ib);
 		for (int i = 0; i < N; ++i) {

--- a/test/algorithm/next_permutation.cpp
+++ b/test/algorithm/next_permutation.cpp
@@ -81,7 +81,7 @@ void test_range()
 		do {
 			std::copy(ia, ia + e, prev);
 			x = ranges::next_permutation(
-					ranges::make_subrange(Iter(ia), Sent(ia + e)));
+					ranges::subrange(Iter(ia), Sent(ia + e)));
 			if (e > 1) {
 				if (x)
 					CHECK(std::lexicographical_compare(prev, prev + e, ia,
@@ -138,7 +138,7 @@ void test_range_comp()
 		do {
 			std::copy(ia, ia + e, prev);
 			x = ranges::next_permutation(
-					ranges::make_subrange(Iter(ia), Sent(ia + e)), C());
+					ranges::subrange(Iter(ia), Sent(ia + e)), C());
 			if (e > 1) {
 				if (x)
 					CHECK(std::lexicographical_compare(prev, prev + e, ia,

--- a/test/algorithm/nth_element.cpp
+++ b/test/algorithm/nth_element.cpp
@@ -45,10 +45,10 @@ test_one(unsigned N, unsigned M)
 	CHECK(stl2::nth_element(array.get(), array.get()+M, array.get()+N) == array.get()+N);
 	CHECK((unsigned)array[M] == M);
 	std::shuffle(array.get(), array.get()+N, gen);
-	CHECK(stl2::nth_element(::as_lvalue(stl2::make_subrange(array.get(), array.get()+N)), array.get()+M) == array.get()+N);
+	CHECK(stl2::nth_element(::as_lvalue(stl2::subrange(array.get(), array.get()+N)), array.get()+M) == array.get()+N);
 	CHECK((unsigned)array[M] == M);
 	std::shuffle(array.get(), array.get()+N, gen);
-	CHECK(stl2::nth_element(stl2::make_subrange(array.get(), array.get()+N), array.get()+M) == array.get()+N);
+	CHECK(stl2::nth_element(stl2::subrange(array.get(), array.get()+N), array.get()+M) == array.get()+N);
 	CHECK((unsigned)array[M] == M);
 	stl2::nth_element(array.get(), array.get()+N, array.get()+N); // begin, end, end
 }

--- a/test/algorithm/partial_sort.cpp
+++ b/test/algorithm/partial_sort.cpp
@@ -64,21 +64,21 @@ test_larger_sorts(int N, int M)
 
 	std::shuffle(array, array + N, gen);
 	res = stl2::partial_sort(
-			::as_lvalue(stl2::make_subrange(array, array + N)), array + M);
+			::as_lvalue(stl2::subrange(array, array + N)), array + M);
 	CHECK(res == array + N);
 	for (int i = 0; i < M; ++i)
 		CHECK(array[i] == i);
 
 	std::shuffle(array, array + N, gen);
 	res2 = stl2::partial_sort(
-			::as_lvalue(stl2::make_subrange(I{array}, S{array + N})),
+			::as_lvalue(stl2::subrange(I{array}, S{array + N})),
 			I{array + M});
 	CHECK(res2.base() == array + N);
 	for (int i = 0; i < M; ++i)
 		CHECK(array[i] == i);
 
 	std::shuffle(array, array + N, gen);
-	auto res3 = stl2::partial_sort(stl2::make_subrange(array, array + N),
+	auto res3 = stl2::partial_sort(stl2::subrange(array, array + N),
 								   array + M);
 	CHECK(res3 == array + N);
 	for (int i = 0; i < M; ++i)
@@ -86,7 +86,7 @@ test_larger_sorts(int N, int M)
 
 	std::shuffle(array, array + N, gen);
 	auto res4 = stl2::partial_sort(
-			stl2::make_subrange(I{array}, S{array + N}), I{array + M});
+			stl2::subrange(I{array}, S{array + N}), I{array + M});
 	CHECK(res4.base() == array + N);
 	for (int i = 0; i < M; ++i)
 		CHECK(array[i] == i);
@@ -106,7 +106,7 @@ test_larger_sorts(int N, int M)
 
 	std::shuffle(array, array + N, gen);
 	res = stl2::partial_sort(
-			::as_lvalue(stl2::make_subrange(array, array + N)), array + M,
+			::as_lvalue(stl2::subrange(array, array + N)), array + M,
 			std::greater<int>());
 	CHECK(res == array + N);
 	for (int i = 0; i < M; ++i)
@@ -114,7 +114,7 @@ test_larger_sorts(int N, int M)
 
 	std::shuffle(array, array + N, gen);
 	res2 = stl2::partial_sort(
-			::as_lvalue(stl2::make_subrange(I{array}, S{array + N})),
+			::as_lvalue(stl2::subrange(I{array}, S{array + N})),
 			I{array + M}, std::greater<int>());
 	CHECK(res2.base() == array + N);
 	for (int i = 0; i < M; ++i)

--- a/test/algorithm/partition.cpp
+++ b/test/algorithm/partition.cpp
@@ -113,7 +113,7 @@ test_range()
 	int ia[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 	Iter r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + 5);
 	for (int* i = ia; i < base(r); ++i)
@@ -121,21 +121,21 @@ test_range()
 	for (int* i = base(r); i < ia + sa; ++i)
 		CHECK(!is_odd()(*i));
 	// check empty
-	r = stl2::partition(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia))),
+	r = stl2::partition(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia))),
 						is_odd());
 	CHECK(base(r) == ia);
 	// check all false
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia);
 	// check all true
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i + 1;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + sa);
 	// check all true but last
@@ -143,7 +143,7 @@ test_range()
 		ia[i] = 2 * i + 1;
 	ia[sa - 1] = 10;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
@@ -155,7 +155,7 @@ test_range()
 		ia[i] = 2 * i + 1;
 	ia[0] = 10;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
@@ -167,7 +167,7 @@ test_range()
 		ia[i] = 2 * i;
 	ia[sa - 1] = 11;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)
@@ -179,7 +179,7 @@ test_range()
 		ia[i] = 2 * i;
 	ia[0] = 11;
 	r = stl2::partition(
-			::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 			is_odd());
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)

--- a/test/algorithm/partition_copy.cpp
+++ b/test/algorithm/partition_copy.cpp
@@ -70,7 +70,7 @@ test_range()
 	int r2[10] = {0};
 	typedef stl2::partition_copy_result<Iter, output_iterator<int*>, int*> P;
 	P p = stl2::partition_copy(
-			::as_lvalue(stl2::make_subrange(Iter(std::begin(ia)),
+			::as_lvalue(stl2::subrange(Iter(std::begin(ia)),
 											  Sent(std::end(ia)))),
 			output_iterator<int*>(r1), r2, is_odd());
 	CHECK(p.in == Iter(std::end(ia)));

--- a/test/algorithm/partition_point.cpp
+++ b/test/algorithm/partition_point.cpp
@@ -98,49 +98,49 @@ test_range()
 {
 	{
 		const int ia[] = {2, 4, 6, 8, 10};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia));
 	}
 	{
 		const int ia[] = {1, 2, 4, 6, 8};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 1));
 	}
 	{
 		const int ia[] = {1, 3, 2, 4, 6};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 2));
 	}
 	{
 		const int ia[] = {1, 3, 5, 2, 4, 6};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 3));
 	}
 	{
 		const int ia[] = {1, 3, 5, 7, 2, 4};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 4));
 	}
 	{
 		const int ia[] = {1, 3, 5, 7, 9, 2};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 5));
 	}
 	{
 		const int ia[] = {1, 3, 5, 7, 9, 11};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::end(ia)))),
 									  is_odd()) == Iter(ia + 6));
 	}
 	{
 		const int ia[] = {1, 3, 5, 2, 4, 6, 7};
-		CHECK(stl2::partition_point(::as_lvalue(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(::as_lvalue(stl2::subrange(Iter(stl2::begin(ia)),
 																Sent(stl2::begin(ia)))),
 									  is_odd()) == Iter(ia));
 	}
@@ -148,7 +148,7 @@ test_range()
 	// An rvalue range
 	{
 		const int ia[] = {1, 3, 5, 7, 9, 2};
-		CHECK(stl2::partition_point(stl2::make_subrange(Iter(stl2::begin(ia)),
+		CHECK(stl2::partition_point(stl2::subrange(Iter(stl2::begin(ia)),
 														 Sent(stl2::end(ia))),
 									  is_odd()) == Iter(ia + 5));
 	}

--- a/test/algorithm/pop_heap.cpp
+++ b/test/algorithm/pop_heap.cpp
@@ -75,14 +75,14 @@ void test_3(int N)
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N);
 	for (int i = N; i > 0; --i) {
-		CHECK(stl2::pop_heap(::as_lvalue(stl2::make_subrange(ia, ia + i)))
+		CHECK(stl2::pop_heap(::as_lvalue(stl2::subrange(ia, ia + i)))
 					  == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1));
 	}
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N);
 	for (int i = N; i > 0; --i) {
-		CHECK(stl2::pop_heap(stl2::make_subrange(ia, ia + i))
+		CHECK(stl2::pop_heap(stl2::subrange(ia, ia + i))
 					  == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1));
 	}
@@ -99,7 +99,7 @@ void test_4(int N)
 	std::make_heap(ia, ia + N);
 	for (int i = N; i > 0; --i) {
 		CHECK(stl2::pop_heap(
-				::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + i))))
+				::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + i))))
 					  == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1));
 	}
@@ -107,7 +107,7 @@ void test_4(int N)
 	std::make_heap(ia, ia + N);
 	for (int i = N; i > 0; --i) {
 		CHECK(stl2::pop_heap(
-				stl2::make_subrange(ia, sentinel<int*>(ia + i)))
+				stl2::subrange(ia, sentinel<int*>(ia + i)))
 					  == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1));
 	}
@@ -154,14 +154,14 @@ void test_7(int N)
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
 	for (int i = N; i > 0; --i) {
-		CHECK(stl2::pop_heap(::as_lvalue(stl2::make_subrange(ia, ia + i)),
+		CHECK(stl2::pop_heap(::as_lvalue(stl2::subrange(ia, ia + i)),
 							 std::greater<int>()) == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1, std::greater<int>()));
 	}
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
 	for (int i = N; i > 0; --i) {
-		CHECK(stl2::pop_heap(stl2::make_subrange(ia, ia + i),
+		CHECK(stl2::pop_heap(stl2::subrange(ia, ia + i),
 							 std::greater<int>()) == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1, std::greater<int>()));
 	}
@@ -178,14 +178,14 @@ void test_8(int N)
 	std::make_heap(ia, ia + N, std::greater<int>());
 	for (int i = N; i > 0; --i) {
 		CHECK(stl2::pop_heap(
-				::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + i))),
+				::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + i))),
 				std::greater<int>()) == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1, std::greater<int>()));
 	}
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
 	for (int i = N; i > 0; --i) {
-		CHECK(stl2::pop_heap(stl2::make_subrange(ia, sentinel<int*>(ia + i)),
+		CHECK(stl2::pop_heap(stl2::subrange(ia, sentinel<int*>(ia + i)),
 							 std::greater<int>()) == ia + i);
 		CHECK(std::is_heap(ia, ia + i - 1, std::greater<int>()));
 	}

--- a/test/algorithm/prev_permutation.cpp
+++ b/test/algorithm/prev_permutation.cpp
@@ -83,7 +83,7 @@ void test_range()
 		do {
 			std::copy(ia, ia + e, prev);
 			x = ranges::prev_permutation(
-					ranges::make_subrange(Iter(ia), Sent(ia + e)));
+					ranges::subrange(Iter(ia), Sent(ia + e)));
 			if (e > 1) {
 				if (!x)
 					CHECK(std::lexicographical_compare(prev, prev + e, ia,
@@ -140,7 +140,7 @@ void test_range_comp()
 		do {
 			std::copy(ia, ia + e, prev);
 			x = ranges::prev_permutation(
-					ranges::make_subrange(Iter(ia), Sent(ia + e)), C());
+					ranges::subrange(Iter(ia), Sent(ia + e)), C());
 			if (e > 1) {
 				if (!x)
 					CHECK(std::lexicographical_compare(prev, prev + e, ia,

--- a/test/algorithm/push_heap.cpp
+++ b/test/algorithm/push_heap.cpp
@@ -135,7 +135,7 @@ TEST_CASE("alg.push_heap")
 		std::shuffle(ia, ia+N, gen);
 		for (int i = 0; i <= N; ++i)
 		{
-			CHECK(stl2::push_heap(stl2::make_subrange(ia, ia+i), std::greater<int>(), &S::i) == ia+i);
+			CHECK(stl2::push_heap(stl2::subrange(ia, ia+i), std::greater<int>(), &S::i) == ia+i);
 			std::transform(ia, ia+i, ib, std::mem_fn(&S::i));
 			CHECK(std::is_heap(ib, ib+i, std::greater<int>()));
 		}

--- a/test/algorithm/remove.cpp
+++ b/test/algorithm/remove.cpp
@@ -59,7 +59,7 @@ void
 test_range() {
 	int ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
 	constexpr unsigned sa = stl2::size(ia);
-	Iter r = stl2::remove(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 2);
+	Iter r = stl2::remove(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 2);
 	CHECK(base(r) == ia + sa - 3);
 	CHECK(ia[0] == 0);
 	CHECK(ia[1] == 1);
@@ -102,7 +102,7 @@ test_range_rvalue() {
 	ia[4].reset(new int(4));
 	ia[6].reset(new int(3));
 	ia[7].reset(new int(4));
-	Iter r = stl2::remove(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), std::unique_ptr<int>());
+	Iter r = stl2::remove(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), std::unique_ptr<int>());
 	CHECK(base(r) == ia + sa - 3);
 	CHECK(*ia[0] == 0);
 	CHECK(*ia[1] == 1);

--- a/test/algorithm/remove_copy.cpp
+++ b/test/algorithm/remove_copy.cpp
@@ -61,7 +61,7 @@ test_range() {
 	int ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
 	constexpr unsigned sa = stl2::size(ia);
 	int ib[sa];
-	stl2::remove_copy_result<InIter, OutIter> r = stl2::remove_copy(::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + sa))),
+	stl2::remove_copy_result<InIter, OutIter> r = stl2::remove_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + sa))),
 													 OutIter(ib), 2);
 	CHECK(base(r.in) == ia + sa);
 	CHECK(base(r.out) == ib + sa - 3);

--- a/test/algorithm/remove_copy_if.cpp
+++ b/test/algorithm/remove_copy_if.cpp
@@ -64,7 +64,7 @@ test_range() {
 	int ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
 	constexpr unsigned sa = stl2::size(ia);
 	int ib[sa];
-	stl2::remove_copy_if_result<InIter, OutIter> r = stl2::remove_copy_if(::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + sa))),
+	stl2::remove_copy_if_result<InIter, OutIter> r = stl2::remove_copy_if(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + sa))),
 														OutIter(ib), [](int i) { return i == 2; });
 	CHECK(base(r.in) == ia + sa);
 	CHECK(base(r.out) == ib + sa - 3);

--- a/test/algorithm/remove_if.cpp
+++ b/test/algorithm/remove_if.cpp
@@ -63,7 +63,7 @@ test_range() {
 	int ia[] = {0, 1, 2, 3, 4, 2, 3, 4, 2};
 	constexpr unsigned sa = stl2::size(ia);
 	using namespace std::placeholders;
-	Iter r = stl2::remove_if(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+	Iter r = stl2::remove_if(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 							 std::bind(std::equal_to<int>(), _1, 2));
 	CHECK(base(r) == ia + sa - 3);
 	CHECK(ia[0] == 0);
@@ -116,7 +116,7 @@ test_range_rvalue() {
 	ia[6].reset(new int(3));
 	ia[7].reset(new int(4));
 	ia[8].reset(new int(2));
-	Iter r = stl2::remove_if(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), pred());
+	Iter r = stl2::remove_if(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), pred());
 	CHECK(base(r) == ia + sa - 3);
 	CHECK(*ia[0] == 0);
 	CHECK(*ia[1] == 1);

--- a/test/algorithm/replace.cpp
+++ b/test/algorithm/replace.cpp
@@ -49,7 +49,7 @@ template<typename Iter, typename Sent = Iter>
 void test_rng() {
 	int ia[] = {0, 1, 2, 3, 4};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
-	auto rng = stl2::make_subrange(Iter(ia), Sent(ia + sa));
+	auto rng = stl2::subrange(Iter(ia), Sent(ia + sa));
 	Iter i = stl2::replace(rng, 2, 5);
 	CHECK(ia[0] == 0);
 	CHECK(ia[1] == 1);

--- a/test/algorithm/replace_copy.cpp
+++ b/test/algorithm/replace_copy.cpp
@@ -53,7 +53,7 @@ void test_rng() {
 	int ia[] = {0, 1, 2, 3, 4};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 	int ib[sa] = {0};
-	auto rng = stl2::make_subrange(InIter(ia), Sent(ia + sa));
+	auto rng = stl2::subrange(InIter(ia), Sent(ia + sa));
 	stl2::replace_copy_result<InIter, OutIter> r = stl2::replace_copy(rng, OutIter(ib), 2, 5);
 	CHECK(base(r.in) == ia + sa);
 	CHECK(base(r.out) == ib + sa);

--- a/test/algorithm/replace_copy_if.cpp
+++ b/test/algorithm/replace_copy_if.cpp
@@ -53,7 +53,7 @@ void test_rng() {
 	int ia[] = {0, 1, 2, 3, 4};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 	int ib[sa] = {0};
-	auto rng = stl2::make_subrange(InIter(ia), Sent(ia + sa));
+	auto rng = stl2::subrange(InIter(ia), Sent(ia + sa));
 	stl2::replace_copy_if_result<InIter, OutIter> r = stl2::replace_copy_if(rng, OutIter(ib),
 														 [](int i) { return 2 == i; }, 5);
 	CHECK(base(r.in) == ia + sa);

--- a/test/algorithm/replace_if.cpp
+++ b/test/algorithm/replace_if.cpp
@@ -49,7 +49,7 @@ template<typename Iter, typename Sent = Iter>
 void test_rng() {
 	int ia[] = {0, 1, 2, 3, 4};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
-	auto rng = stl2::make_subrange(Iter(ia), Sent(ia + sa));
+	auto rng = stl2::subrange(Iter(ia), Sent(ia + sa));
 	Iter i = stl2::replace_if(rng, [](int i) { return i == 2; }, 5);
 	CHECK(ia[0] == 0);
 	CHECK(ia[1] == 1);

--- a/test/algorithm/reverse.cpp
+++ b/test/algorithm/reverse.cpp
@@ -75,37 +75,37 @@ void test()
 		int ia[] = {0};
 		const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 		Iter i0 = stl2::reverse(
-				::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia))));
+				::as_lvalue(stl2::subrange(Iter(ia), Sent(ia))));
 		::check_equal(ia, {0});
 		CHECK(i0 == Iter(ia));
 		Iter i1 = stl2::reverse(
-				::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))));
+				::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))));
 		::check_equal(ia, {0});
 		CHECK(i1 == Iter(ia + sa));
 
 		int ib[] = {0, 1};
 		const unsigned sb = sizeof(ib) / sizeof(ib[0]);
 		Iter i2 = stl2::reverse(
-				::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))));
+				::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))));
 		::check_equal(ib, {1, 0});
 		CHECK(i2 == Iter(ib + sb));
 
 		int ic[] = {0, 1, 2};
 		const unsigned sc = sizeof(ic) / sizeof(ic[0]);
 		Iter i3 = stl2::reverse(
-				::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))));
+				::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))));
 		::check_equal(ic, {2, 1, 0});
 		CHECK(i3 == Iter(ic + sc));
 
 		int id[] = {0, 1, 2, 3};
 		const unsigned sd = sizeof(id) / sizeof(id[0]);
 		Iter i4 = stl2::reverse(
-				::as_lvalue(stl2::make_subrange(Iter(id), Sent(id + sd))));
+				::as_lvalue(stl2::subrange(Iter(id), Sent(id + sd))));
 		::check_equal(id, {3, 2, 1, 0});
 		CHECK(i4 == Iter(id + sd));
 
 		// rvalue range
-		auto i5 = stl2::reverse(stl2::make_subrange(Iter(id), Sent(id + sd)));
+		auto i5 = stl2::reverse(stl2::subrange(Iter(id), Sent(id + sd)));
 		::check_equal(id, {0, 1, 2, 3});
 		CHECK(i5 == Iter(id + sd));
 	}

--- a/test/algorithm/reverse_copy.cpp
+++ b/test/algorithm/reverse_copy.cpp
@@ -83,13 +83,13 @@ void test()
 		const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 		int ja[sa] = {-1};
 		P p0 = stl2::reverse_copy(
-				::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia))),
+				::as_lvalue(stl2::subrange(Iter(ia), Sent(ia))),
 				OutIter(ja));
 		::check_equal(ja, {-1});
 		CHECK(p0.in == Iter(ia));
 		CHECK(base(p0.out) == ja);
 		P p1 = stl2::reverse_copy(
-				::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))),
+				::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
 				OutIter(ja));
 		::check_equal(ja, {0});
 		CHECK(p1.in == Iter(ia + sa));
@@ -99,7 +99,7 @@ void test()
 		const unsigned sb = sizeof(ib) / sizeof(ib[0]);
 		int jb[sb] = {-1};
 		P p2 = stl2::reverse_copy(
-				::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))),
+				::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))),
 				OutIter(jb));
 		::check_equal(jb, {1, 0});
 		CHECK(p2.in == Iter(ib + sb));
@@ -109,7 +109,7 @@ void test()
 		const unsigned sc = sizeof(ic) / sizeof(ic[0]);
 		int jc[sc] = {-1};
 		P p3 = stl2::reverse_copy(
-				::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))),
+				::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))),
 				OutIter(jc));
 		::check_equal(jc, {2, 1, 0});
 		CHECK(p3.in == Iter(ic + sc));
@@ -119,7 +119,7 @@ void test()
 		const unsigned sd = sizeof(id) / sizeof(id[0]);
 		int jd[sd] = {-1};
 		P p4 = stl2::reverse_copy(
-				::as_lvalue(stl2::make_subrange(Iter(id), Sent(id + sd))),
+				::as_lvalue(stl2::subrange(Iter(id), Sent(id + sd))),
 				OutIter(jd));
 		::check_equal(jd, {3, 2, 1, 0});
 		CHECK(p4.in == Iter(id + sd));
@@ -128,7 +128,7 @@ void test()
 		// test rvalue ranges
 		std::memset(jd, 0, sizeof(jd));
 		auto p5 = stl2::reverse_copy(
-				stl2::make_subrange(Iter(id), Sent(id + sd)), OutIter(jd));
+				stl2::subrange(Iter(id), Sent(id + sd)), OutIter(jd));
 		::check_equal(jd, {3, 2, 1, 0});
 		CHECK(p5.in == Iter(id + sd));
 		CHECK(base(p4.out) == jd + sd);

--- a/test/algorithm/rotate_copy.cpp
+++ b/test/algorithm/rotate_copy.cpp
@@ -159,27 +159,27 @@ void test_rng()
 	int ib[sa] = {0};
 
 	auto r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia))),
 			InIter(ia), OutIter(ib));
 	CHECK(base(r.in) == ia);
 	CHECK(base(r.out) == ib);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 1))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 1))),
 			InIter(ia), OutIter(ib));
 	CHECK(base(r.in) == ia + 1);
 	CHECK(base(r.out) == ib + 1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 1))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 1))),
 			InIter(ia + 1), OutIter(ib));
 	CHECK(base(r.in) == ia + 1);
 	CHECK(base(r.out) == ib + 1);
 	CHECK(ib[0] == 0);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 2))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 2))),
 			InIter(ia), OutIter(ib));
 	CHECK(base(r.in) == ia + 2);
 	CHECK(base(r.out) == ib + 2);
@@ -187,7 +187,7 @@ void test_rng()
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 2))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 2))),
 			InIter(ia + 1), OutIter(ib));
 	CHECK(base(r.in) == ia + 2);
 	CHECK(base(r.out) == ib + 2);
@@ -195,7 +195,7 @@ void test_rng()
 	CHECK(ib[1] == 0);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 2))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 2))),
 			InIter(ia + 2), OutIter(ib));
 	CHECK(base(r.in) == ia + 2);
 	CHECK(base(r.out) == ib + 2);
@@ -203,7 +203,7 @@ void test_rng()
 	CHECK(ib[1] == 1);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 3))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 3))),
 			InIter(ia), OutIter(ib));
 	CHECK(base(r.in) == ia + 3);
 	CHECK(base(r.out) == ib + 3);
@@ -212,7 +212,7 @@ void test_rng()
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 3))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 3))),
 			InIter(ia + 1), OutIter(ib));
 	CHECK(base(r.in) == ia + 3);
 	CHECK(base(r.out) == ib + 3);
@@ -221,7 +221,7 @@ void test_rng()
 	CHECK(ib[2] == 0);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 3))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 3))),
 			InIter(ia + 2), OutIter(ib));
 	CHECK(base(r.in) == ia + 3);
 	CHECK(base(r.out) == ib + 3);
@@ -230,7 +230,7 @@ void test_rng()
 	CHECK(ib[2] == 1);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 3))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 3))),
 			InIter(ia + 3), OutIter(ib));
 	CHECK(base(r.in) == ia + 3);
 	CHECK(base(r.out) == ib + 3);
@@ -239,7 +239,7 @@ void test_rng()
 	CHECK(ib[2] == 2);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 4))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 4))),
 			InIter(ia), OutIter(ib));
 	CHECK(base(r.in) == ia + 4);
 	CHECK(base(r.out) == ib + 4);
@@ -249,7 +249,7 @@ void test_rng()
 	CHECK(ib[3] == 3);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 4))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 4))),
 			InIter(ia + 1), OutIter(ib));
 	CHECK(base(r.in) == ia + 4);
 	CHECK(base(r.out) == ib + 4);
@@ -259,7 +259,7 @@ void test_rng()
 	CHECK(ib[3] == 0);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 4))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 4))),
 			InIter(ia + 2), OutIter(ib));
 	CHECK(base(r.in) == ia + 4);
 	CHECK(base(r.out) == ib + 4);
@@ -269,7 +269,7 @@ void test_rng()
 	CHECK(ib[3] == 1);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 4))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 4))),
 			InIter(ia + 3), OutIter(ib));
 	CHECK(base(r.in) == ia + 4);
 	CHECK(base(r.out) == ib + 4);
@@ -279,7 +279,7 @@ void test_rng()
 	CHECK(ib[3] == 2);
 
 	r = stl2::rotate_copy(
-			::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + 4))),
+			::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + 4))),
 			InIter(ia + 4), OutIter(ib));
 	CHECK(base(r.in) == ia + 4);
 	CHECK(base(r.out) == ib + 4);

--- a/test/algorithm/search.cpp
+++ b/test/algorithm/search.cpp
@@ -120,73 +120,73 @@ test_range_impl()
 {
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia), Sent2(ia))).begin() ==Iter1(ia));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia), Sent2(ia + 1))).begin() ==Iter1(ia));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + 1), Sent2(ia + 2))).begin() ==Iter1(ia+1));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + 2), Sent2(ia + 2))).begin() ==Iter1(ia));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + 2), Sent2(ia + 3))).begin() ==Iter1(ia+2));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + 2), Sent2(ia + 3))).begin() ==Iter1(ia+2));
 	CHECK(stl2::search(::as_lvalue(
-			stl2::make_subrange(Iter1(ia), Sent1(ia))), stl2::make_subrange(
+			stl2::subrange(Iter1(ia), Sent1(ia))), stl2::subrange(
 			Iter2(ia + 2), Sent2(ia + 3))).begin() ==Iter1(ia));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + sa - 1), Sent2(ia + sa))).begin() ==Iter1(ia+sa-1));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia + sa - 3), Sent2(ia + sa))).begin() ==Iter1(ia+sa-3));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + sa))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + sa))), stl2::subrange(
 			Iter2(ia), Sent2(ia + sa))).begin() ==Iter1(ia));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia),
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia),
 														 Sent1(ia + sa
-																	   - 1))), stl2::make_subrange(
+																	   - 1))), stl2::subrange(
 			Iter2(ia), Sent2(ia + sa))).begin() ==Iter1(ia+sa-1));
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ia), Sent1(ia
-																				  + 1))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ia), Sent1(ia
+																				  + 1))), stl2::subrange(
 			Iter2(ia), Sent2(ia + sa))).begin() ==Iter1(ia+1));
 	int ib[] = {0, 1, 2, 0, 1, 2, 3, 0, 1, 2, 3, 4};
 	const unsigned sb = sizeof(ib) / sizeof(ib[0]);
 	int ic[] = {1};
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ib), Sent1(ib
-																				  + sb))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ib), Sent1(ib
+																				  + sb))), stl2::subrange(
 			Iter2(ic), Sent2(ic + 1))).begin() ==Iter1(ib+1));
 	int id[] = {1, 2};
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ib), Sent1(ib
-																				  + sb))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ib), Sent1(ib
+																				  + sb))), stl2::subrange(
 			Iter2(id), Sent2(id + 2))).begin() ==Iter1(ib+1));
 	int ie[] = {1, 2, 3};
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ib), Sent1(ib
-																				  + sb))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ib), Sent1(ib
+																				  + sb))), stl2::subrange(
 			Iter2(ie), Sent2(ie + 3))).begin() ==Iter1(ib+4));
 	int ig[] = {1, 2, 3, 4};
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ib), Sent1(ib
-																				  + sb))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ib), Sent1(ib
+																				  + sb))), stl2::subrange(
 			Iter2(ig), Sent2(ig + 4))).begin() ==Iter1(ib+8));
 	int ih[] = {0, 1, 1, 1, 1, 2, 3, 0, 1, 2, 3, 4};
 	const unsigned sh = sizeof(ih) / sizeof(ih[0]);
 	int ii[] = {1, 1, 2};
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ih), Sent1(ih
-																				  + sh))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ih), Sent1(ih
+																				  + sh))), stl2::subrange(
 			Iter2(ii), Sent2(ii + 3))).begin() ==Iter1(ih+3));
 	int ij[] = {0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0};
 	const unsigned sj = sizeof(ij) / sizeof(ij[0]);
 	int ik[] = {0, 0, 0, 0, 1, 1, 1, 1, 0, 0};
 	const unsigned sk = sizeof(ik) / sizeof(ik[0]);
-	CHECK(stl2::search(::as_lvalue(stl2::make_subrange(Iter1(ij), Sent1(ij
-																				  + sj))), stl2::make_subrange(
+	CHECK(stl2::search(::as_lvalue(stl2::subrange(Iter1(ij), Sent1(ij
+																				  + sj))), stl2::subrange(
 			Iter2(ik), Sent2(ik + sk))).begin() ==Iter1(ij+6));
 }
 
@@ -247,7 +247,7 @@ TEST_CASE("alg.search")
 	// Test counted ranges
 	{
 		int in[] = {0,1,2,3,4,5};
-		auto rng = stl2::make_subrange(
+		auto rng = stl2::subrange(
 					 stl2::make_counted_iterator(
 					   bidirectional_iterator<int*>(in), 6),
 					 stl2::default_sentinel);

--- a/test/algorithm/search_n.cpp
+++ b/test/algorithm/search_n.cpp
@@ -100,44 +100,44 @@ void
 test_range_impl() {
 	int ia[] = {0, 1, 2, 3, 4, 5};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 0, 0).begin() == Iter(ia));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 1, 0).begin() == Iter(ia + 0));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 2, 0).begin() == Iter(ia + sa));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), sa, 0).begin() == Iter(ia + sa));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 0, 3).begin() == Iter(ia));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 1, 3).begin() == Iter(ia + 3));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 2, 3).begin() == Iter(ia + sa));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), sa, 3).begin() == Iter(ia + sa));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 0, 5).begin() == Iter(ia));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 1, 5).begin() == Iter(ia + 5));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), 2, 5).begin() == Iter(ia + sa));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ia), Sent(ia + sa))), sa, 5).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 0, 0).begin() == Iter(ia));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 1, 0).begin() == Iter(ia + 0));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 2, 0).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), sa, 0).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 0, 3).begin() == Iter(ia));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 1, 3).begin() == Iter(ia + 3));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 2, 3).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), sa, 3).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 0, 5).begin() == Iter(ia));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 1, 5).begin() == Iter(ia + 5));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), 2, 5).begin() == Iter(ia + sa));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))), sa, 5).begin() == Iter(ia + sa));
 
 	int ib[] = {0, 0, 1, 1, 2, 2};
 	const unsigned sb = sizeof(ib) / sizeof(ib[0]);
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 0, 0).begin() == Iter(ib));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 1, 0).begin() == Iter(ib + 0));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 2, 0).begin() == Iter(ib + 0));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 3, 0).begin() == Iter(ib + sb));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), sb, 0).begin() == Iter(ib + sb));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 0, 1).begin() == Iter(ib));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 1, 1).begin() == Iter(ib + 2));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 2, 1).begin() == Iter(ib + 2));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 3, 1).begin() == Iter(ib + sb));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), sb, 1).begin() == Iter(ib + sb));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 0, 2).begin() == Iter(ib));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 1, 2).begin() == Iter(ib + 4));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 2, 2).begin() == Iter(ib + 4));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), 3, 2).begin() == Iter(ib + sb));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ib), Sent(ib + sb))), sb, 2).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 0, 0).begin() == Iter(ib));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 1, 0).begin() == Iter(ib + 0));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 2, 0).begin() == Iter(ib + 0));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 3, 0).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), sb, 0).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 0, 1).begin() == Iter(ib));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 1, 1).begin() == Iter(ib + 2));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 2, 1).begin() == Iter(ib + 2));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 3, 1).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), sb, 1).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 0, 2).begin() == Iter(ib));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 1, 2).begin() == Iter(ib + 4));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 2, 2).begin() == Iter(ib + 4));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), 3, 2).begin() == Iter(ib + sb));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ib), Sent(ib + sb))), sb, 2).begin() == Iter(ib + sb));
 
 	int ic[] = {0, 0, 0};
 	const unsigned sc = sizeof(ic) / sizeof(ic[0]);
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))), 0, 0).begin() == Iter(ic));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))), 1, 0).begin() == Iter(ic));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))), 2, 0).begin() == Iter(ic));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))), 3, 0).begin() == Iter(ic));
-	CHECK(stl2::search_n(::as_lvalue(stl2::make_subrange(Iter(ic), Sent(ic + sc))), 4, 0).begin() == Iter(ic + sc));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))), 0, 0).begin() == Iter(ic));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))), 1, 0).begin() == Iter(ic));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))), 2, 0).begin() == Iter(ic));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))), 3, 0).begin() == Iter(ic));
+	CHECK(stl2::search_n(::as_lvalue(stl2::subrange(Iter(ic), Sent(ic + sc))), 4, 0).begin() == Iter(ic + sc));
 }
 
 template<class Iter, class Iter2>
@@ -187,7 +187,7 @@ TEST_CASE("alg.search_n")
 	// Test counted ranges
 	{
 		int in[] = {0,1,2,2,4,5};
-		auto rng = stl2::make_subrange(
+		auto rng = stl2::subrange(
 					 stl2::make_counted_iterator(bidirectional_iterator<int*>(in), 6),
 					 stl2::default_sentinel);
 		auto it = stl2::search_n(rng, 2, 2).begin();

--- a/test/algorithm/shuffle.cpp
+++ b/test/algorithm/shuffle.cpp
@@ -58,7 +58,7 @@ TEST_CASE("alg.shuffle")
 		std::iota(ib, ib + s, 0);
 		std::iota(orig, orig + s, 0);
 		std::minstd_rand g;
-		auto rng = stl2::make_subrange(random_access_iterator<int*>(ia),  random_access_iterator<int*>(ia+s));
+		auto rng = stl2::subrange(random_access_iterator<int*>(ia),  random_access_iterator<int*>(ia+s));
 		stl2::shuffle(rng, g);
 		CHECK(!stl2::equal(ia, orig));
 		CHECK(stl2::shuffle(ib, g) == stl2::end(ib));

--- a/test/algorithm/sort_heap.cpp
+++ b/test/algorithm/sort_heap.cpp
@@ -68,7 +68,7 @@ void test_3(int N)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N);
-	CHECK(stl2::sort_heap(::as_lvalue(stl2::make_subrange(ia, ia + N)))
+	CHECK(stl2::sort_heap(::as_lvalue(stl2::subrange(ia, ia + N)))
 				  == ia + N);
 	CHECK(std::is_sorted(ia, ia + N));
 	delete[] ia;
@@ -82,7 +82,7 @@ void test_4(int N)
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N);
 	CHECK(stl2::sort_heap(
-			::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + N))))
+			::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + N))))
 				  == ia + N);
 	CHECK(std::is_sorted(ia, ia + N));
 	delete[] ia;
@@ -120,7 +120,7 @@ void test_7(int N)
 		ia[i] = i;
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
-	CHECK(stl2::sort_heap(::as_lvalue(stl2::make_subrange(ia, ia + N)),
+	CHECK(stl2::sort_heap(::as_lvalue(stl2::subrange(ia, ia + N)),
 						  std::greater<int>()) == ia + N);
 	CHECK(std::is_sorted(ia, ia + N, std::greater<int>()));
 	delete[] ia;
@@ -134,13 +134,13 @@ void test_8(int N)
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
 	CHECK(stl2::sort_heap(
-			::as_lvalue(stl2::make_subrange(ia, sentinel<int*>(ia + N))),
+			::as_lvalue(stl2::subrange(ia, sentinel<int*>(ia + N))),
 			std::greater<int>()) == ia + N);
 	CHECK(std::is_sorted(ia, ia + N, std::greater<int>()));
 
 	std::shuffle(ia, ia + N, gen);
 	std::make_heap(ia, ia + N, std::greater<int>());
-	CHECK(stl2::sort_heap(stl2::make_subrange(ia, sentinel<int*>(ia + N)),
+	CHECK(stl2::sort_heap(stl2::subrange(ia, sentinel<int*>(ia + N)),
 						  std::greater<int>()) == ia + N);
 	CHECK(std::is_sorted(ia, ia + N, std::greater<int>()));
 

--- a/test/algorithm/stable_partition.cpp
+++ b/test/algorithm/stable_partition.cpp
@@ -291,7 +291,7 @@ test_range()
 				  {4, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
@@ -318,7 +318,7 @@ test_range()
 				  {4, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
@@ -333,18 +333,18 @@ test_range()
 		CHECK(ap[9] == P{4, 2});
 		// check empty
 		r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap))),
 				odd_first());
 		CHECK(base(r) == ap);
 		// check one true
 		r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + 1))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + 1))),
 				odd_first());
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
 		// check one false
 		r = ranges::stable_partition(::as_lvalue(
-				ranges::make_subrange(Iter(ap + 4), Sent(ap + 5))),
+				ranges::subrange(Iter(ap + 4), Sent(ap + 5))),
 									 odd_first());
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[4] == P{0, 1});
@@ -362,7 +362,7 @@ test_range()
 				  {8, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap);
 		CHECK(ap[0] == P{0, 1});
@@ -389,7 +389,7 @@ test_range()
 				  {9, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + size);
 		CHECK(ap[0] == P{1, 1});
@@ -416,7 +416,7 @@ test_range()
 				  {8, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
@@ -443,7 +443,7 @@ test_range()
 				  {1, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 2});
@@ -470,7 +470,7 @@ test_range()
 				  {9, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 2});
@@ -497,7 +497,7 @@ test_range()
 				  {0, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
-				::as_lvalue(ranges::make_subrange(Iter(ap), Sent(ap + size))),
+				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
 				odd_first());
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 1});

--- a/test/algorithm/swap_ranges.cpp
+++ b/test/algorithm/swap_ranges.cpp
@@ -91,7 +91,7 @@ void test_rng_3()
 {
 	int i[3] = {1, 2, 3};
 	int j[3] = {4, 5, 6};
-	auto r = stl2::swap_ranges(as_lvalue(stl2::make_subrange(Iter1(i), Iter1(i+3))), Iter2(j));
+	auto r = stl2::swap_ranges(as_lvalue(stl2::subrange(Iter1(i), Iter1(i+3))), Iter2(j));
 	CHECK(base(r.in1) == i+3);
 	CHECK(base(r.in2) == j+3);
 	CHECK(i[0] == 4);
@@ -102,7 +102,7 @@ void test_rng_3()
 	CHECK(j[2] == 3);
 
 	using Sent1 = typename sentinel_type<Iter1>::type;
-	r = stl2::swap_ranges(as_lvalue(stl2::make_subrange(Iter1(j), Sent1(j+3))), Iter2(i));
+	r = stl2::swap_ranges(as_lvalue(stl2::subrange(Iter1(j), Sent1(j+3))), Iter2(i));
 	CHECK(base(r.in1) == j+3);
 	CHECK(base(r.in2) == i+3);
 	CHECK(i[0] == 1);
@@ -119,8 +119,8 @@ void test_rng_4()
 	int i[3] = {1, 2, 3};
 	int j[4] = {4, 5, 6, 7};
 	auto r = stl2::swap_ranges(
-		as_lvalue(stl2::make_subrange(Iter1(i), Iter1(i+3))),
-		as_lvalue(stl2::make_subrange(Iter2(j), Iter2(j+4))));
+		as_lvalue(stl2::subrange(Iter1(i), Iter1(i+3))),
+		as_lvalue(stl2::subrange(Iter2(j), Iter2(j+4))));
 	CHECK(base(r.in1) == i+3);
 	CHECK(base(r.in2) == j+3);
 	CHECK(i[0] == 4);
@@ -134,8 +134,8 @@ void test_rng_4()
 	using Sent1 = typename sentinel_type<Iter1>::type;
 	using Sent2 = typename sentinel_type<Iter2>::type;
 	r = stl2::swap_ranges(
-		as_lvalue(stl2::make_subrange(Iter1(j), Sent1(j+4))),
-		as_lvalue(stl2::make_subrange(Iter2(i), Sent2(i+3))));
+		as_lvalue(stl2::subrange(Iter1(j), Sent1(j+4))),
+		as_lvalue(stl2::subrange(Iter2(i), Sent2(i+3))));
 	CHECK(base(r.in1) == j+3);
 	CHECK(base(r.in2) == i+3);
 	CHECK(i[0] == 1);
@@ -147,8 +147,8 @@ void test_rng_4()
 	CHECK(j[3] == 7);
 
 	auto r2 = stl2::swap_ranges(
-		stl2::make_subrange(Iter1(j), Sent1(j+4)),
-		stl2::make_subrange(Iter2(i), Sent2(i+3)));
+		stl2::subrange(Iter1(j), Sent1(j+4)),
+		stl2::subrange(Iter2(i), Sent2(i+3)));
 	CHECK(base(r2.in1) == j+3);
 	CHECK(base(r2.in2) == i+3);
 	CHECK(i[0] == 4);

--- a/test/algorithm/unique.cpp
+++ b/test/algorithm/unique.cpp
@@ -57,7 +57,7 @@ struct range_call {
 	template <class B, class E, class... Args>
 	auto operator()(B&& It, E&& e, Args&& ... args) const
 	{
-		auto rng = stl2::make_subrange(begin_t{It}, sentinel_t{e});
+		auto rng = stl2::subrange(begin_t{It}, sentinel_t{e});
 		return stl2::unique(rng, std::forward<Args>(args)...);
 	}
 };

--- a/test/algorithm/unique_copy.cpp
+++ b/test/algorithm/unique_copy.cpp
@@ -146,7 +146,7 @@ test_range() {
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 	int ja[sa] = {-1};
 	count_equal::count = 0;
-	stl2::unique_copy_result<InIter, OutIter> r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ia), Sent(ia + sa))),
+	stl2::unique_copy_result<InIter, OutIter> r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ia), Sent(ia + sa))),
 													 OutIter(ja), count_equal());
 	CHECK(base(r.in) == ia + sa);
 	CHECK(base(r.out) == ja + sa);
@@ -157,7 +157,7 @@ test_range() {
 	const unsigned sb = sizeof(ib) / sizeof(ib[0]);
 	int jb[sb] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ib), Sent(ib + sb))), OutIter(jb), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ib), Sent(ib + sb))), OutIter(jb), count_equal());
 	CHECK(base(r.in) == ib + sb);
 	CHECK(base(r.out) == jb + sb);
 	CHECK(jb[0] == 0);
@@ -168,7 +168,7 @@ test_range() {
 	const unsigned sc = sizeof(ic) / sizeof(ic[0]);
 	int jc[sc] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ic), Sent(ic + sc))), OutIter(jc), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ic), Sent(ic + sc))), OutIter(jc), count_equal());
 	CHECK(base(r.in) == ic + sc);
 	CHECK(base(r.out) == jc + 1);
 	CHECK(jc[0] == 0);
@@ -178,7 +178,7 @@ test_range() {
 	const unsigned sd = sizeof(id) / sizeof(id[0]);
 	int jd[sd] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(id), Sent(id + sd))), OutIter(jd), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(id), Sent(id + sd))), OutIter(jd), count_equal());
 	CHECK(base(r.in) == id + sd);
 	CHECK(base(r.out) == jd + 2);
 	CHECK(jd[0] == 0);
@@ -189,7 +189,7 @@ test_range() {
 	const unsigned se = sizeof(ie) / sizeof(ie[0]);
 	int je[se] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ie), Sent(ie + se))), OutIter(je), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ie), Sent(ie + se))), OutIter(je), count_equal());
 	CHECK(base(r.in) == ie + se);
 	CHECK(base(r.out) == je + 3);
 	CHECK(je[0] == 0);
@@ -201,7 +201,7 @@ test_range() {
 	const unsigned sg = sizeof(ig) / sizeof(ig[0]);
 	int jg[sg] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ig), Sent(ig + sg))), OutIter(jg), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ig), Sent(ig + sg))), OutIter(jg), count_equal());
 	CHECK(base(r.in) == ig + sg);
 	CHECK(base(r.out) == jg + 2);
 	CHECK(jg[0] == 0);
@@ -212,7 +212,7 @@ test_range() {
 	const unsigned sh = sizeof(ih) / sizeof(ih[0]);
 	int jh[sh] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ih), Sent(ih + sh))), OutIter(jh), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ih), Sent(ih + sh))), OutIter(jh), count_equal());
 	CHECK(base(r.in) == ih + sh);
 	CHECK(base(r.out) == jh + 2);
 	CHECK(jh[0] == 0);
@@ -223,7 +223,7 @@ test_range() {
 	const unsigned si = sizeof(ii) / sizeof(ii[0]);
 	int ji[si] = {-1};
 	count_equal::count = 0;
-	r = stl2::unique_copy(::as_lvalue(stl2::make_subrange(InIter(ii), Sent(ii + si))), OutIter(ji), count_equal());
+	r = stl2::unique_copy(::as_lvalue(stl2::subrange(InIter(ii), Sent(ii + si))), OutIter(ji), count_equal());
 	CHECK(base(r.in) == ii + si);
 	CHECK(base(r.out) == ji + 3);
 	CHECK(ji[0] == 0);
@@ -291,7 +291,7 @@ TEST_CASE("alg.unique_copy")
 		stl2::unique_copy_result<S const *, S *> r = stl2::unique_copy(ia, ib, stl2::equal_to<>(), &S::i);
 		CHECK(r.in == stl2::end(ia));
 		CHECK(r.out == ib + 7);
-		check_equal(stl2::make_subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
+		check_equal(stl2::subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
 	}
 
 #ifdef HAVE_RVALUE_RANGES
@@ -307,7 +307,7 @@ TEST_CASE("alg.unique_copy")
 		CHECK(r.in == stl2::end(ia));
 #endif
 		CHECK(r.out == ib + 7);
-		check_equal(stl2::make_subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
+		check_equal(stl2::subrange(ib, ib+7), {S{1,1},S{2,2},S{3,3},S{4,5},S{5,6},S{6,9},S{7,10}});
 	}
 #endif
 }

--- a/test/basic_algorithm/set_ops.cpp
+++ b/test/basic_algorithm/set_ops.cpp
@@ -32,10 +32,10 @@ TEST_CASE("alg.basic.merge")
     }
 
     SECTION("with iterators") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{oss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{oss2},
             std::istream_iterator<int>{});
         auto result = nano::back_inserter(out);
@@ -85,10 +85,10 @@ TEST_CASE("alg.basic.set_difference")
     }
 
     SECTION("with ranges") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{iss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{iss2},
             std::istream_iterator<int>{});
         nano::set_difference(rng1, rng2, nano::back_inserter(vec), nano::greater<>{});
@@ -114,10 +114,10 @@ TEST_CASE("alg.basic.set_intersection")
     }
 
     SECTION("with ranges") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{iss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{iss2},
             std::istream_iterator<int>{});
         nano::set_intersection(rng1, rng2, nano::back_inserter(vec), nano::greater<>{});
@@ -143,10 +143,10 @@ TEST_CASE("alg.basic.set_symmetric_difference")
     }
 
     SECTION("with ranges") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{iss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{iss2},
             std::istream_iterator<int>{});
         nano::set_symmetric_difference(rng1, rng2, nano::back_inserter(vec), nano::greater<>{});
@@ -172,10 +172,10 @@ TEST_CASE("alg.basic.set_union")
     }
 
     SECTION("with ranges") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{iss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{iss2},
             std::istream_iterator<int>{});
         nano::set_union(rng1, rng2, nano::back_inserter(vec), nano::greater<>{});
@@ -206,13 +206,13 @@ TEST_CASE("alg.basic.includes")
     }
 
     SECTION("with ranges") {
-        auto rng1 = nano::make_subrange(
+        auto rng1 = nano::subrange(
             std::istream_iterator<int>{iss1},
             std::istream_iterator<int>{});
-        auto rng2 = nano::make_subrange(
+        auto rng2 = nano::subrange(
             std::istream_iterator<int>{iss2},
             std::istream_iterator<int>{});
-        auto rng3 = nano::make_subrange(
+        auto rng3 = nano::subrange(
             std::istream_iterator<int>{iss3},
             std::istream_iterator<int>{});
         REQUIRE(nano::includes(rng1, rng2, nano::greater<>{}));

--- a/test/basic_algorithm/sorting_ops.cpp
+++ b/test/basic_algorithm/sorting_ops.cpp
@@ -149,7 +149,7 @@ TEST_CASE("alg.basic.partial_sort_copy")
     }
 
     SECTION("with ranges") {
-        auto in_rng = nano::make_subrange(
+        auto in_rng = nano::subrange(
             std::istream_iterator<int>{iss},
             std::istream_iterator<int>{});
         rng::partial_sort_copy(in_rng, vec);
@@ -173,7 +173,7 @@ TEST_CASE("alg.basic.partial_sort_copy (with comparator)")
     }
 
     SECTION("with ranges") {
-        auto in_rng = nano::make_subrange(
+        auto in_rng = nano::subrange(
             std::istream_iterator<int>{iss},
             std::istream_iterator<int>{});
         rng::partial_sort_copy(in_rng, vec, rng::greater<>{});

--- a/test/iterator/istream_iterator.cpp
+++ b/test/iterator/istream_iterator.cpp
@@ -91,13 +91,13 @@ TEST_CASE("iter.istream_iterator")
 	{
 		std::istringstream is("5 4 3 2 1 0");
 		::check_equal(
-			make_subrange(istream_iterator<int>{is}, default_sentinel),
+			subrange(istream_iterator<int>{is}, default_sentinel),
 				{5, 4, 3, 2, 1, 0});
 	}
 	{
 		std::istringstream is("0.9 1.8 2.4 3.3");
 		::check_equal(
-			make_subrange(istream_iterator<double>{is}, default_sentinel),
+			subrange(istream_iterator<double>{is}, default_sentinel),
 				{0.9, 1.8, 2.4, 3.3});
 	}
 

--- a/test/iterator/istreambuf_iterator.cpp
+++ b/test/iterator/istreambuf_iterator.cpp
@@ -93,8 +93,8 @@ TEST_CASE("iter.istreambuf_iterator") {
 	{
 		static const char hw[] = "Hello, world!";
 		std::istringstream is(hw);
-		::check_equal(make_subrange(I{is}, default_sentinel),
-									make_subrange(hw + 0, hw + size(hw) - 1));
+		::check_equal(subrange(I{is}, default_sentinel),
+									subrange(hw + 0, hw + size(hw) - 1));
 	}
 
 	{

--- a/test/iterator/ostreambuf_iterator.cpp
+++ b/test/iterator/ostreambuf_iterator.cpp
@@ -54,7 +54,7 @@ TEST_CASE("iter.ostreambuf_iterator") {
 
 	{
 		static const char hw[] = "Hello, world!";
-		auto hw_range = make_subrange(__stl2::begin(hw), __stl2::end(hw) - 1);
+		auto hw_range = subrange(__stl2::begin(hw), __stl2::end(hw) - 1);
 		std::ostringstream os;
 		auto r = ::copy(hw_range, I{os});
 		//CHECK(r.out() != default_sentinel{});

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -16,10 +16,8 @@
 #include <utility>
 #include <nanorange/view/subrange.hpp>
 
-#ifdef NANO_HAVE_CPP17
 #include <string_view>
 #include <nanorange/algorithm/find.hpp>
-#endif
 
 #include "catch.hpp"
 
@@ -186,7 +184,6 @@ static_assert(ranges::Iterator<I>, "");
 static_assert(ranges::Iterator<CI>, "");
 
 void test_string_view_p0970() {
-#if defined(NANO_HAVE_CPP17)
 	// basic_string_views are non-dangling
 	using I = ranges::iterator_t<std::string_view>;
 	static_assert(ranges::Same<I, decltype(ranges::begin(std::declval<std::string_view>()))>);
@@ -200,7 +197,6 @@ void test_string_view_p0970() {
 		static_assert(ranges::Same<I, decltype(result)>);
 		CHECK(result == std::string_view{hw}.begin() + 7);
 	}
-#endif
 }
 
 }

--- a/test/ranges/istream_range.cpp
+++ b/test/ranges/istream_range.cpp
@@ -51,7 +51,7 @@ TEST_CASE("rng.istream_range")
         constexpr const char test[] = "abcd3210";
         std::istringstream ss{test};
         ::check_equal(ranges::istream_range<moveonly>(ss),
-                      ranges::make_subrange(test, test + sizeof(test) - 1));
+                      ranges::subrange(test, test + sizeof(test) - 1));
     }
 
     // Default-constructed istream_ranges are empty

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -75,8 +75,8 @@ public:
                               using S = typename sentinel_type<I>::type;
                               check(algo(begin, end, rest...));
                               check(algo(begin, S{base(end)}, rest...));
-                              check(algo(::rvalue_if<RvalueOK>(nano::make_subrange(begin, end)), rest...));
-                              check(algo(::rvalue_if<RvalueOK>(nano::make_subrange(begin, S{base(end)})), rest...));
+                              check(algo(::rvalue_if<RvalueOK>(nano::subrange(begin, end)), rest...));
+                              check(algo(::rvalue_if<RvalueOK>(nano::subrange(begin, S{base(end)})), rest...));
                           }};
     }
 };
@@ -107,11 +107,11 @@ public:
                               using S2 = typename sentinel_type<I2>::type;
                               check(algo(begin1, end1, begin2, end2, rest...));
                               check(algo(begin1, S1{base(end1)}, begin2, S2{base(end2)}, rest...));
-                              check(algo(::rvalue_if<RvalueOK1>(nano::make_subrange(begin1, end1)),
-                                          ::rvalue_if<RvalueOK2>(nano::make_subrange(begin2, end2)),
+                              check(algo(::rvalue_if<RvalueOK1>(nano::subrange(begin1, end1)),
+                                          ::rvalue_if<RvalueOK2>(nano::subrange(begin2, end2)),
                                           rest...));
-                              check(algo(::rvalue_if<RvalueOK1>(nano::make_subrange(begin1, S1{base(end1)})),
-                                          ::rvalue_if<RvalueOK2>(nano::make_subrange(begin2, S2{base(end2)})),
+                              check(algo(::rvalue_if<RvalueOK1>(nano::subrange(begin1, S1{base(end1)})),
+                                          ::rvalue_if<RvalueOK2>(nano::subrange(begin2, S2{base(end2)})),
                                           rest...));
                           }};
     }

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -51,7 +51,6 @@ TEST_CASE("view.subrange") {
 	}
 
 	// Deduction guides and tuple interface
-#ifdef NANO_HAVE_CPP17
 	{
 		std::vector vec{1, 2, 3, 4, 5};
 		auto r = subrange{vec};
@@ -59,5 +58,4 @@ TEST_CASE("view.subrange") {
 		CHECK(i == vec.begin());
 		CHECK(s == vec.end());
 	}
-#endif
 }

--- a/test/view/subrange.cpp
+++ b/test/view/subrange.cpp
@@ -23,7 +23,7 @@ TEST_CASE("view.subrange") {
 	{
 		static constexpr int some_ints[] = {2, 3, 5, 7, 11, 13};
 		static constexpr std::size_t n = size(some_ints);
-		auto r = make_subrange(some_ints + 0, some_ints + n);
+		auto r = subrange(some_ints + 0, some_ints + n);
 		using R = decltype(r);
 		static_assert(models::View<R>, "");
 		static_assert(models::SizedRange<R>, "");
@@ -40,7 +40,7 @@ TEST_CASE("view.subrange") {
 
 	{
         std::vector<int> v1{1, 2, 3, 4, 5};
-        auto r = make_subrange(v1);
+        auto r = subrange(v1);
 
         CHECK(!r.empty());
         CHECK(size(r) == size(v1));


### PR DESCRIPTION
NanoRange was originally conceived as a "small" implementation of the Ranges TS, or at least small compared to Range-V3. Over time it has grown substantially, and quite a lot of complexity and workarounds have been added to support older C++14 compilers (in particular GCC5).

By requiring C++17, we can keep NanoRange closer in line with what it was intended to be, by removing workarounds for older compilers. In addition, being able to use C++17 features (in particular if constexpr and constexpr lambdas) means that we can (hopefully) try to keep our compile times down.

I imagine the intersection of users who want the latest cutting-edge C++ library features, but are stuck with older compilers, is rather small. For those that do exist, Range-V3 still supports C++14 for now.