### PR TITLE
Use lambda binding workaround on MSVC 16.2/19.22

### DIFF
--- a/include/nanorange/detail/macros.hpp
+++ b/include/nanorange/detail/macros.hpp
@@ -51,7 +51,7 @@ inline namespace ranges                                                        \
 #define NANO_END_NAMESPACE_STD }
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1921
+#if defined(_MSC_VER) && _MSC_VER < 1923
 #define NANO_MSVC_LAMBDA_PIPE_WORKAROUND 1
 #endif
 


### PR DESCRIPTION
Testing seemed to suggest this had been fixed in 16.1, but perhaps there has been a regression.

Fixes #54