### PR TITLE
Work around really odd GCC9 bug

### DIFF
--- a/test/view/reverse_view.cpp
+++ b/test/view/reverse_view.cpp
@@ -25,16 +25,17 @@ TEST_CASE("view.reverse") {
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};
 		auto x = rg | view::reverse;
 		::check_equal(x, {9,8,7,6,5,4,3,2,1,0});
+		// FIXME: Really bizarre GCC9 bug (?)
+		// If you remove this ForwardRange check, then the RandomAccessRange
+		// check below fails (in fact, even InputRange fails).
+		// It all works fine on GCC7 and 8, Clang and MSVC
+		// I have no idea what's going on.
+		static_assert(ForwardRange<decltype(x)>);
 		static_assert(View<decltype(x)>, "");
 		static_assert(Range<const decltype(x)>, "");
 		static_assert(SizedRange<decltype(x)>, "");
 		static_assert(CommonRange<decltype(x)>, "");
-		// FIXME FIXME: I have no idea why GCC9.1 doesn't like this
-		// It works fine on GCC 7&8, Clang and MSVC
-		// Compiler bug?
-#if !(defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 9 && __GNUC_MINOR__ == 1)
 		static_assert(RandomAccessRange<decltype(x)>, "");
-#endif
 	}
 	{
 		int rg[] = {0,1,2,3,4,5,6,7,8,9};


### PR DESCRIPTION
Given X = reverse_view<int(&)[10]>, GCC9 for some reason gets very confused and fails the static_assert if you ask it to check RandomAccessRange<X> *after* checking View<X>. In fact, it won't even admit that X is an InputRange -- but if you give it an identical definition of the InputRange concept locally then it passes.

If you remove the View check, then it works. If you add a ForwardRange check *before* the View check -- as in this commit -- then it works (but, curiously, a prior InputRange check is not sufficient to make it pass).

This is all very strange and I have no idea what's going on -- in fact, it's all a little concerning. Fortunately, everything works okay in GCC7 and 8, Clang and MSVC, so at this point I can only assume it's a really odd compiler bug.