### PR TITLE
Fix broken piping on MSVC (again)

### DIFF
--- a/include/nanorange/detail/macros.hpp
+++ b/include/nanorange/detail/macros.hpp
@@ -51,7 +51,7 @@ inline namespace ranges                                                        \
 #define NANO_END_NAMESPACE_STD }
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER < 1924
+#if defined(_MSC_VER)
 #define NANO_MSVC_LAMBDA_PIPE_WORKAROUND 1
 #endif
 

--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -233,17 +233,13 @@ struct filter_view_fn {
     template <typename Pred>
     constexpr auto operator()(Pred pred) const
     {
-#ifdef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
-        return detail::rao_proxy{std::bind([](auto&& r, auto p) {
-            return filter_view{std::forward<decltype(r)>(r), std::move(p)};
-        }, std::placeholders::_1, std::move(pred))};
-#else
         return detail::rao_proxy{[p = std::move(pred)] (auto&& r) mutable
+#ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
             -> decltype(filter_view{std::forward<decltype(r)>(r), std::declval<Pred&&>()})
+#endif
         {
             return filter_view{std::forward<decltype(r)>(r), std::move(p)};
         }};
-#endif
     }
 
     template <typename R, typename Pred>

--- a/include/nanorange/views/transform.hpp
+++ b/include/nanorange/views/transform.hpp
@@ -371,18 +371,13 @@ struct transform_view_fn {
     template <typename F>
     constexpr auto operator()(F f) const
     {
-#ifdef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
-        return detail::rao_proxy{std::bind(
-            [](auto&& r, auto f) {
-                return transform_view{std::forward<decltype(r)>(r), std::move(f)};
-            },
-            std::placeholders::_1, std::move(f))};
-#else
         return detail::rao_proxy{[f = std::move(f)](auto&& r) mutable
-            -> decltype(transform_view{std::forward<decltype(r)>(r), std::declval<F&&>()}) {
+#ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
+            -> decltype(transform_view{std::forward<decltype(r)>(r), std::declval<F&&>()})
+#endif
+        {
             return transform_view{std::forward<decltype(r)>(r), std::move(f)};
         }};
-#endif
     }
 };
 


### PR DESCRIPTION
Thanks to @QuellaZhang for pointing out that the problem with our lambda piping approach is not inheriting from a lambda-as-template-arg (as I thought), but actually the complex explicit return type of the lambda itself.

By using a deduced return type when the compiler is MSVC we can use the same nifty approach to piping everywhere. Using a deduced return type like this doesn't actually lose us very much either.

This issue with return types is fixed with MSVC's new lambda processor, which is enabled with /std:c++latest or /experimental:newLambdaProcessor. AFAIK there is no way to detect at compile-time whether this is in use, so for now we'll unconditionally use the workaround if the compiler is MSVC. When the new processor becomes the default, we can add a version check to the workaround macro.

This commit hopefully finally fixes #54 properly