### PR TITLE
Improve make_single_header tool

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,10 @@
 
 add_executable(make_single_header make_single_header.cpp)
 target_compile_features(make_single_header PRIVATE cxx_std_17)
+target_link_libraries(make_single_header PRIVATE nanorange)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-target_link_libraries(make_single_header PRIVATE stdc++fs)
+  target_link_libraries(make_single_header PRIVATE stdc++fs)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_link_libraries(make_single_header PRIVATE c++fs)
 endif()


### PR DESCRIPTION
We have a shiny new ranges library, we may as well use it.

Also, link to the std::filesystem library if using Clang/libc++.

Unfortunately the match_results forward declaration causes problems with libstdc++, because it's actually defined in an inline namespace. I ought to fix that.