### PR TITLE
Make istream_view::iterator copyable (again)

### DIFF
--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -43,7 +43,9 @@ namespace filter_view_ {
 template <typename V, typename Pred>
 struct filter_view : view_interface<filter_view<V, Pred>> {
 
-    static_assert(input_range<V>);
+    // FIXME: GCC9 recursive constraint (?) problems again
+    // static_assert(input_range<V>);
+    static_assert(input_iterator<iterator_t<V>>);
     static_assert(indirect_unary_predicate<Pred, iterator_t<V>>);
     static_assert(view<V>);
     static_assert(std::is_object_v<Pred>);

--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -167,21 +167,34 @@ private:
 
         constexpr sentinel_t<V> base() const { return end_; }
 
+        // Make these friend functions templates to keep MSVC happy
+#if (defined(_MSC_VER) && _MSC_VER < 1922)
+        template <typename = void>
+#endif
         friend constexpr bool operator==(const iterator& i, const sentinel& s)
         {
             return i.base() == s.end_;
         }
 
+#if (defined(_MSC_VER) && _MSC_VER < 1922)
+        template <typename = void>
+#endif
         friend constexpr bool operator==(const sentinel& s, const iterator& i)
         {
             return i == s;
         }
 
+#if (defined(_MSC_VER) && _MSC_VER < 1922)
+        template <typename = void>
+#endif
         friend constexpr bool operator!=(const iterator& i, const sentinel& s)
         {
             return !(i == s);
         }
 
+#if (defined(_MSC_VER) && _MSC_VER < 1922)
+        template <typename = void>
+#endif
         friend constexpr bool operator!=(const sentinel& s, const iterator& i)
         {
             return !(i == s);

--- a/include/nanorange/views/istream.hpp
+++ b/include/nanorange/views/istream.hpp
@@ -67,11 +67,14 @@ private:
             : parent_(std::addressof(parent))
         {}
 
+        // Disable move-only iterator until views support them properly
+#if 0
         iterator(const iterator&) = delete;
         iterator(iterator&&) = default;
 
         iterator& operator=(const iterator&) = delete;
         iterator& operator=(iterator&&) = default;
+#endif
         iterator& operator++()
         {
             *parent_->stream_ >> parent_->object_;

--- a/test/views/filter_view.cpp
+++ b/test/views/filter_view.cpp
@@ -12,8 +12,10 @@
 #include <nanorange/views/filter.hpp>
 #include <nanorange/views/iota.hpp>
 #include <nanorange/views/ref.hpp>
+#include <nanorange/views/istream.hpp>
 #include <memory>
 #include <list>
+#include <sstream>
 
 #include "../catch.hpp"
 #include "../test_utils.hpp"
@@ -139,5 +141,12 @@ TEST_CASE("views.filter")
         auto yes = [](int) { return true; };
         auto const rng = views::iota(0) | views::filter(yes);
         views::all(rng);
+    }
+
+    {
+        std::istringstream ss("1 2 3 4 5 6 7 8 9 10");
+        auto is_even = [](int i) { return i % 2 == 0; };
+        auto rng = nano::istream_view<int>(ss) | views::filter(is_even);
+        ::check_equal(rng, {2, 4, 6, 8, 10});
     }
 }


### PR DESCRIPTION
While the concepts (and the istream_view spec) have been updated for move-only iterators, the views have not (yet).

Since it's handy to be able to apply adaptors to an istream_view, we'll comment out the move constructor definitions for now.

(Oh, and also work around yet another mysterious GCC constraint failure, grrr....)