### PR TITLE
split_view fixes

### DIFF
--- a/include/nanorange/views/split.hpp
+++ b/include/nanorange/views/split.hpp
@@ -316,6 +316,7 @@ private:
 
         template <typename B = Base>
         friend constexpr auto operator!=(const inner_iterator& x, const inner_iterator& y)
+            -> std::enable_if_t<forward_range<B>, bool>
         {
             return !(x == y);
         }

--- a/include/nanorange/views/split.hpp
+++ b/include/nanorange/views/split.hpp
@@ -171,15 +171,15 @@ private:
             if (get_current() == end) {
                 return *this;
             }
-            const auto sub = subrange{parent_->data_.pattern_};
-            if (sub.begin() == sub.end()) {
+            const auto [pbegin, pend] = subrange{parent_->data_.pattern_};
+            if (pbegin == pend) {
                 ++get_current();
             } else {
                 do {
-                    const auto res = ranges::mismatch(get_current(), end,
-                                                      sub.begin(), sub.end());
-                    if (res.in2 == sub.end()) {
-                        get_current() = res.in1;
+                    const auto [b, p] = ranges::mismatch(get_current(), end,
+                                                         pbegin, pend);
+                    if (p == pend) {
+                        get_current() = b;
                         break;
                     }
                 } while (++get_current() != end);
@@ -248,9 +248,7 @@ private:
             if (cur == end) {
                 return true;
             }
-            auto sub = subrange{i_.parent_->data_.pattern_};
-            auto pcur = sub.begin();
-            auto pend = sub.end();
+            auto [pcur, pend] = subrange{i_.parent_->data_.pattern_};
             if (pcur == pend) {
                 return incremented_;
             }


### PR DESCRIPTION
 * Fix missing constraint in split_view::inner_iterator::operator!=(iterator, iterator)
 * Use structured bindings like the spec tells us to