### PR TITLE
Add pointer and reference typedefs to view iterators

### DIFF
--- a/include/nanorange/views/common.hpp
+++ b/include/nanorange/views/common.hpp
@@ -143,7 +143,7 @@ inline constexpr bool is_raco<common_view_fn> = true;
 
 namespace views {
 
-NANO_INLINE_VAR(detail::common_view_fn, common)
+NANO_INLINE_VAR(::nano::detail::common_view_fn, common)
 
 } // namespace views
 

--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -65,6 +65,9 @@ private:
             decltype(detail::filter_view_iter_cat_helper<V>());
         using value_type = iter_value_t<iterator_t<V>>;
         using difference_type = iter_difference_t<iterator_t<V>>;
+        // Extension: legacy typedefs
+        using pointer = iterator_t<V>;
+        using reference = iter_reference_t<iterator_t<V>>;
 
         iterator() = default;
         constexpr iterator(filter_view& parent, iterator_t<V> current)

--- a/include/nanorange/views/iota.hpp
+++ b/include/nanorange/views/iota.hpp
@@ -80,6 +80,9 @@ private:
         using iterator_category = decltype(detail::iota_view_iter_cat_helper<W>());
         using value_type = W;
         using difference_type = detail::iota_diff_t<W>;
+        // Extension: legacy typedefs
+        using pointer = void;
+        using reference = W;
 
         iterator() = default;
 

--- a/include/nanorange/views/join.hpp
+++ b/include/nanorange/views/join.hpp
@@ -115,11 +115,13 @@ private:
     public:
         //using iterator_concept = ...
         using iterator_category = decltype(detail::join_view_iter_cat_helper<Base>());
-
         using value_type = range_value_t<range_reference_t<Base>>;
         using difference_type = nano::common_type_t<
             range_difference_t<Base>,
             range_difference_t<range_reference_t<Base>>>;
+        // Extension: legacy typedefs
+        using pointer = iterator_t<Base>;
+        using reference = range_reference_t<range_reference_t<Base>>;
 
         iterator() = default;
 

--- a/include/nanorange/views/split.hpp
+++ b/include/nanorange/views/split.hpp
@@ -139,6 +139,9 @@ private:
         };
 
         using difference_type = range_difference_t<Base>;
+        // Extension: legacy typedefs
+        using pointer = void;
+        using reference = value_type;
 
         outer_iterator() = default;
 

--- a/include/nanorange/views/transform.hpp
+++ b/include/nanorange/views/transform.hpp
@@ -57,6 +57,9 @@ private:
         using value_type =
             detail::remove_cvref_t<invoke_result_t<F&, range_reference_t<Base>>>;
         using difference_type = range_difference_t<Base>;
+        // Extension: legacy typedefs
+        using pointer = void;
+        using reference = invoke_result_t<F&, range_reference_t<Base>>;
 
         iterator() = default;
 

--- a/test/views/filter_view.cpp
+++ b/test/views/filter_view.cpp
@@ -41,70 +41,70 @@ TEST_CASE("views.filter")
 {
 	using namespace ranges;
 
-	int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-	static_assert(size(views::all(rgi))==10);
+        {
+            int rgi[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            static_assert(size(views::all(rgi)) == 10);
 
-	auto rng = rgi | views::filter(is_odd());
-	//auto rng = views::filter(rgi, is_odd());
-	static_assert(same_as<int &, decltype(*begin(rgi))>);
-	static_assert(same_as<int &, decltype(*begin(rng))>);
-	static_assert(view<decltype(rng)>);
-	static_assert(input_range<decltype(rng)>);
-	static_assert(common_range<decltype(rng)>);
-	static_assert(!sized_range<decltype(rng)>);
-	static_assert(bidirectional_range<decltype(rng)>);
-	static_assert(!random_access_range<decltype(rng)>);
-	::check_equal(rng, {1,3,5,7,9});
+            auto rng = rgi | views::filter(is_odd());
+            // auto rng = views::filter(rgi, is_odd());
+            static_assert(same_as<int&, decltype(*begin(rgi))>);
+            static_assert(same_as<int&, decltype(*begin(rng))>);
+            static_assert(view<decltype(rng)>);
+            static_assert(input_range<decltype(rng)>);
+            static_assert(common_range<decltype(rng)>);
+            static_assert(!sized_range<decltype(rng)>);
+            static_assert(bidirectional_range<decltype(rng)>);
+            static_assert(!random_access_range<decltype(rng)>);
+            ::check_equal(rng, {1, 3, 5, 7, 9});
 
-	//CHECK_EQUAL(rng | views::reverse, {9,7,5,3,1});
-	//auto tmp = rng | views::reverse;
-	//CHECK(&*begin(tmp) == &rgi[8]);
+            // CHECK_EQUAL(rng | views::reverse, {9,7,5,3,1});
+            // auto tmp = rng | views::reverse;
+            // CHECK(&*begin(tmp) == &rgi[8]);
 
-	// auto rng2 = views::counted(rgi, 10) | views::remove_if(not_fn(is_odd()));
-	// static_assert(Same<int &, decltype(*begin(rng2))>);
-	// static_assert(BidirectionalView<__f<decltype(rng2)>>);
-	// static_assert(!RandomAccessView<__f<decltype(rng2)>>);
-	// static_assert(CommonView<__f<decltype(rng2)>>);
-	// static_assert(!SizedView<__f<decltype(rng2)>>);
-	// CHECK_EQUAL(rng2, {1,3,5,7,9});
-	// CHECK(&*begin(rng2) == &rgi[0]);
+            // auto rng2 = views::counted(rgi, 10) | views::remove_if(not_fn(is_odd())); static_assert(Same<int &, decltype(*begin(rng2))>);
+            // static_assert(BidirectionalView<__f<decltype(rng2)>>);
+            // static_assert(!RandomAccessView<__f<decltype(rng2)>>);
+            // static_assert(CommonView<__f<decltype(rng2)>>);
+            // static_assert(!SizedView<__f<decltype(rng2)>>);
+            // CHECK_EQUAL(rng2, {1,3,5,7,9});
+            // CHECK(&*begin(rng2) == &rgi[0]);
 
-	// auto rng3 = views::counted(bidirectional_iterator<int*>{rgi}, 10) | views::remove_if(is_even());
-	// static_assert(Same<int &, decltype(*begin(rng3))>);
-	// static_assert(BidirectionalView<__f<decltype(rng3)>>);
-	// static_assert(!RandomAccessView<__f<decltype(rng3)>>);
-	// static_assert(!CommonView<__f<decltype(rng3)>>);
-	// static_assert(!SizedView<__f<decltype(rng3)>>);
-	// CHECK_EQUAL(rng3, {1,3,5,7,9});
-	// CHECK(&*begin(rng3) == &rgi[0]);
-	// CHECK(&*prev(next(begin(rng3))) == &rgi[0]);
+            // auto rng3 = views::counted(bidirectional_iterator<int*>{rgi}, 10) | views::remove_if(is_even()); static_assert(Same<int &, decltype(*begin(rng3))>);
+            // static_assert(BidirectionalView<__f<decltype(rng3)>>);
+            // static_assert(!RandomAccessView<__f<decltype(rng3)>>);
+            // static_assert(!CommonView<__f<decltype(rng3)>>);
+            // static_assert(!SizedView<__f<decltype(rng3)>>);
+            // CHECK_EQUAL(rng3, {1,3,5,7,9});
+            // CHECK(&*begin(rng3) == &rgi[0]);
+            // CHECK(&*prev(next(begin(rng3))) == &rgi[0]);
 
-	// Test remove_if with a mutable lambda
-	bool flag = false;
-	auto f = [flag](int) mutable { return flag = !flag;};
-	detail::semiregular_box<decltype(f)> b{f};
-	auto b2 = b;
-	b = b2;
-	auto mutable_rng = views::filter(rgi, [flag](int) mutable { return flag = !flag;});
-	::check_equal(mutable_rng, {1,3,5,7,9});
-	static_assert(range<decltype(mutable_rng)>);
-	static_assert(copyable<decltype(mutable_rng)>);
-	static_assert(!view<decltype(mutable_rng) const>);
+            // Test remove_if with a mutable lambda
+            bool flag = false;
+            auto f = [flag](int) mutable { return flag = !flag; };
+            detail::semiregular_box<decltype(f)> b{f};
+            auto b2 = b;
+            b = b2;
+            auto mutable_rng = views::filter(
+                rgi, [flag](int) mutable { return flag = !flag; });
+            ::check_equal(mutable_rng, {1, 3, 5, 7, 9});
+            static_assert(range<decltype(mutable_rng)>);
+            static_assert(copyable<decltype(mutable_rng)>);
+            static_assert(!view<decltype(mutable_rng) const>);
 
-	// {
-	//	 const std::array<int, 3> a{{0, 1, 2}};
-	//	 const std::vector<int> b{3, 4, 5, 6};
+            // {
+            //	 const std::array<int, 3> a{{0, 1, 2}};
+            //	 const std::vector<int> b{3, 4, 5, 6};
 
-	//	 auto r = views::concat(a, b);
-	//	 auto f = [](int i) { return i != 1 && i != 5; };
-	//	 auto r2 = r | views::remove_if(f);
-	//	 CHECK_EQUAL(r2, {1,5});
-	// }
+            //	 auto r = views::concat(a, b);
+            //	 auto f = [](int i) { return i != 1 && i != 5; };
+            //	 auto r2 = r | views::remove_if(f);
+            //	 CHECK_EQUAL(r2, {1,5});
+            // }
 
-	// {
-	//	 auto rng = debug_input_view<int const>{rgi} | views::remove_if(is_even{});
-	//	 CHECK_EQUAL(rng, {1,3,5,7,9});
-	// }
+            // {
+            //	 auto rng = debug_input_view<int const>{rgi} | views::remove_if(is_even{}); 	 CHECK_EQUAL(rng, {1,3,5,7,9});
+            // }
+        }
 
 	{
 		// Test operator-> with pointer
@@ -148,5 +148,14 @@ TEST_CASE("views.filter")
         auto is_even = [](int i) { return i % 2 == 0; };
         auto rng = nano::istream_view<int>(ss) | views::filter(is_even);
         ::check_equal(rng, {2, 4, 6, 8, 10});
+    }
+
+    // Check conversion to vector
+    {
+        auto is_even = [](int i) { return i % 2 == 0; };
+        auto rng = views::iota(0, 10) | views::filter(is_even);
+        static_assert(common_range<decltype(rng)>);
+        const std::vector<int> vec(rng.begin(), rng.end());
+        ::check_equal(vec, {0, 2, 4, 6, 8});
     }
 }

--- a/test/views/iota.cpp
+++ b/test/views/iota.cpp
@@ -75,4 +75,12 @@ TEST_CASE("views.iota")
 
         ::check_equal(vec, {0, 0, 0, 4, 5});
     }
+
+    {
+        // Check conversion to vector
+        auto rng = nano::views::iota(0, 5);
+        static_assert(nano::common_range<decltype(rng)>);
+        auto vec = std::vector<int>(rng.begin(), rng.end());
+        ::check_equal(vec, {0, 1, 2, 3, 4});
+    }
 }

--- a/test/views/join_view.cpp
+++ b/test/views/join_view.cpp
@@ -79,4 +79,13 @@ TEST_CASE("views.join")
 		static_assert(!forward_range<decltype(rng2)>);
 		static_assert(!common_range<decltype(rng2)>);
 	}
+
+	// Check conversion to string
+	{
+	    const std::vector<std::string> vec{"the", "quick", "brown", "fox"};
+            auto rng = vec | views::join;
+            static_assert(common_range<decltype(rng)>);
+            const std::string out(rng.begin(), rng.end());
+            CHECK(out == "thequickbrownfox");
+	}
 }

--- a/test/views/split_view.cpp
+++ b/test/views/split_view.cpp
@@ -13,6 +13,8 @@
 #include <nanorange/views/empty.hpp>
 #include <nanorange/iterator/istreambuf_iterator.hpp>
 #include <nanorange/views/join.hpp>
+#include <nanorange/views/common.hpp>
+#include <nanorange/views/transform.hpp>
 #include <nanorange/algorithm/equal.hpp>
 #include "../catch.hpp"
 #include "../test_utils.hpp"
@@ -228,6 +230,21 @@ TEST_CASE("views.split") {
 		CHECK(i != sv.end());
 		++i;
 		CHECK(i == sv.end());
+	}
+
+	// Check conversion to vector
+	{
+	    const auto to_string = [](auto&& r) {
+	        auto c = std::forward<decltype(r)>(r) | views::common;
+	        return std::string(begin(c), end(c));
+	    };
+	    const std::string hello = "Hello World";
+	    auto rng = hello
+	        | views::split(' ')
+	        | views::transform(to_string);
+	    static_assert(common_range<decltype(rng)>);
+	    const auto vec = std::vector<std::string>(rng.begin(), rng.end());
+	    ::check_equal(vec, {"Hello", "World"});
 	}
 
 #ifdef _MSC_VER

--- a/test/views/transform_view.cpp
+++ b/test/views/transform_view.cpp
@@ -13,6 +13,7 @@
 #include <nanorange/views/filter.hpp>
 #include <nanorange/views/iota.hpp>
 #include <nanorange/views/reverse.hpp>
+#include <nanorange/views/common.hpp>
 
 #include "../catch.hpp"
 #include "../test_utils.hpp"
@@ -73,4 +74,12 @@ TEST_CASE("views.transform") {
             views::iota(0) | views::filter(id) | views::transform(id);
         }
 
+        // Check conversion to vector
+        {
+            auto square = [](int i) { return i * i; };
+
+            auto rng = views::iota(0, 5) | views::transform(square);
+            auto vec = std::vector<int>(begin(rng), end(rng));
+            ::check_equal(vec, {0, 1, 4, 9, 16});
+        }
 }


### PR DESCRIPTION
Since we're not (yet?) doing Range-V3 style "deep integration", hacking into std::iterator_traits, we need to provide all 5 typedefs in our new view iterators to use them with legacy algorithms -- or, more usefully,  with container contructors.

They all have value_type, difference_type and iterator_category typedefs already, so this commit adds reference (defined to be the return type of op*) and pointer (defined to be the return type of op-> where that exists, else void).

Only the views which (can potentially) return the same type for begin() and end() need these -- others (such as istream_view) must be routed through common_iterator, which already provides the necessary typedefs.

Also, add some tests to make sure range conversion works as expected.