### PR TITLE
Fix common_reference error on MSVC 19.22

### DIFF
--- a/include/nanorange/detail/common_reference.hpp
+++ b/include/nanorange/detail/common_reference.hpp
@@ -43,9 +43,28 @@ using copy_cv_t = typename copy_cv<T, U>::type;
 template <typename T>
 using cref_t = std::add_lvalue_reference_t<const std::remove_reference_t<T>>;
 
+// Workaround for "term does not evaluate to a function taking 0 arguments"
+// error in MSVC 19.22 (issue #75)
+#if defined(_MSC_VER) && _MSC_VER >= 1922
+template <typename, typename, typename = void>
+struct cond_res {};
+
+template <typename T, typename U>
+struct cond_res<T, U, std::void_t<decltype(false ? std::declval<T (&)()>()()
+                                                 : std::declval<U (&)()>()())>>
+{
+    using type = decltype(false ? std::declval<T (&)()>()()
+                                : std::declval<U (&)()>()());
+};
+
+template <typename T, typename U>
+using cond_res_t = typename cond_res<T, U>::type;
+#else
 template <typename T, typename U>
 using cond_res_t = decltype(false ? std::declval<T (&)()>()()
                                   : std::declval<U (&)()>()());
+#endif
+
 
 // For some value of "simple"
 template <typename A, typename B,


### PR DESCRIPTION
MSVC 19.22 has a hard error when just #including NanoRange, reporting that "term does not evaluate to a function taking 0 arguments" when evaluating `cond_res_t` in detail/common_reference.hpp

I'm not sure of the cause -- this works correctly in GCC, Clang, and previous versions of MSVC, and it seems to me as if evaluation should take place within a SFINAE context and therefore not be a hard error -- but we'll work around it by using another level of indirection/SFINAE.

Because the workaround is likely to be a tiny bit more expensive than a straight alias template, we'll put it behind an #ifdef to ony use it where necessary.

Fixes #75