### PR TITLE
Add std::span implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,8 @@ else ()
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/memory/uninitialized_move.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/memory/uninitialized_value_construct.hpp
 
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/span.hpp
+
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/views/all.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/views/common.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/views/counted.hpp

--- a/include/nanorange.hpp
+++ b/include/nanorange.hpp
@@ -14,6 +14,7 @@
 #include <nanorange/memory.hpp>
 #include <nanorange/random.hpp>
 #include <nanorange/ranges.hpp>
+#include <nanorange/span.hpp>
 #include <nanorange/type_traits.hpp>
 #include <nanorange/utility.hpp>
 #include <nanorange/views.hpp>

--- a/include/nanorange/span.hpp
+++ b/include/nanorange/span.hpp
@@ -1,0 +1,396 @@
+
+/*
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_SPAN_HPP_INCLUDED
+#define NANORANGE_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+
+#include <nanorange/detail/type_traits.hpp>
+
+NANO_BEGIN_NAMESPACE
+
+inline constexpr std::size_t dynamic_extent = -1;
+
+namespace span_ {
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+}
+
+using span_::span;
+
+namespace detail {
+
+template <typename E, std::size_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* ptr, std::size_t /*unused*/) noexcept : ptr(ptr)
+    {}
+
+    E* ptr = nullptr;
+    static inline constexpr std::size_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* ptr, std::size_t size) noexcept
+        : ptr(ptr), size(size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, std::void_t<decltype(std::size(std::declval<T>())),
+                                        decltype(std::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = remove_cvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E, std::void_t<decltype(std::data(std::declval<T>()))>>
+    : std::is_convertible<
+          std::remove_pointer_t<decltype(std::data(std::declval<T>()))> (*)[],
+          E (*)[]> {};
+
+} // namespace detail
+
+namespace span_ {
+
+template <typename ElementType, std::size_t Extent>
+class span {
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = std::remove_cv_t<ElementType>;
+    using index_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    static constexpr index_type extent = Extent;
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E == 0), int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    constexpr span(pointer ptr, index_type count) : storage_(ptr, count)
+    {
+        assert(extent == dynamic_extent || count == extent);
+    }
+
+    constexpr span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        assert(extent == dynamic_extent ||
+               last_elem - first_elem == static_cast<std::ptrdiff_t>(extent));
+    }
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              std::enable_if_t<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<value_type, N>&, ElementType>::value,
+                  int> = 0>
+    constexpr span(std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              std::enable_if_t<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<value_type, N>&, ElementType>::value,
+                  int> = 0>
+    constexpr span(const std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont) : storage_(std::data(cont), std::size(cont))
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
+        : storage_(std::data(cont), std::size(cont))
+    {}
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::size_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    constexpr span& operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::size_t Count>
+    constexpr span<element_type, Count> first() const
+    {
+        assert(Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::size_t Count>
+    constexpr span<element_type, Count> last() const
+    {
+        assert(Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    constexpr subspan_return_t<Offset, Count> subspan() const
+    {
+        assert(Offset <= size() &&
+               (Count == dynamic_extent || Offset + Count <= size()));
+        return {data() + Offset,
+                Count != dynamic_extent ? Count : size() - Offset};
+    }
+
+    constexpr span<element_type, dynamic_extent> first(index_type count) const
+    {
+        assert(count <= size());
+        return {data(), count};
+    }
+
+    constexpr span<element_type, dynamic_extent> last(index_type count) const
+    {
+        assert(count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    constexpr span<element_type, dynamic_extent>
+    subspan(index_type offset, index_type count = dynamic_extent) const
+    {
+        assert(offset <= size() &&
+               (count == dynamic_extent || offset + count <= size()));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr index_type size() const noexcept { return storage_.size; }
+
+    constexpr index_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
+
+    // [span.elem], span element access
+    constexpr reference operator[](index_type idx) const
+    {
+        assert(idx < size());
+        return *(data() + idx);
+    }
+
+    constexpr reference front() const
+    {
+        assert(!empty());
+        return *data();
+    }
+
+    constexpr reference back() const
+    {
+        assert(!empty());
+        return *(data() + (size() - 1));
+    }
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+    constexpr const_iterator cend() const noexcept { return end(); }
+
+    constexpr reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    constexpr reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+    constexpr const_reverse_iterator crbegin() const noexcept
+    {
+        return const_reverse_iterator(cend());
+    }
+
+    constexpr const_reverse_iterator crend() const noexcept
+    {
+        return const_reverse_iterator(cbegin());
+    }
+
+    // FIXME: should just be span, not span&&
+    friend constexpr iterator begin(span&& s) noexcept { return s.begin(); }
+
+    friend constexpr iterator end(span&& s) noexcept { return s.end(); }
+
+private:
+    storage_type storage_{};
+};
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename Container::value_type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+} // namespace span_
+
+template <typename ElementType, std::size_t Extent>
+span<const std::byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const std::byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, size_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<std::byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<std::byte*>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t I, typename T, std::size_t Extent>
+constexpr T& get(span<T, Extent> s)
+{
+    static_assert(Extent != dynamic_extent && I < Extent);
+    return s[I];
+}
+
+NANO_END_NAMESPACE
+
+namespace std {
+
+template <typename ElementType, size_t Extent>
+class tuple_size<::nano::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <typename ElementType>
+class tuple_size<::nano::span<ElementType, ::nano::dynamic_extent>>; // not defined
+
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, ::nano::span<ElementType, Extent>> {
+public:
+    static_assert(Extent != ::nano::dynamic_extent &&
+                      I < Extent);
+    using type = ElementType;
+};
+
+} // end namespace std
+
+#endif // TCB_SPAN_HPP_INCLUDED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -182,7 +182,7 @@ add_executable(test_nanorange
     #views/repeat_view.cpp
     views/reverse_view.cpp
     views/single_view.cpp
-    #views/span.cpp
+    views/span.cpp
     views/split_view.cpp
     views/subrange.cpp
     #views/take_exactly_view.cpp

--- a/test/views/span.cpp
+++ b/test/views/span.cpp
@@ -14,9 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <stl2/detail/span.hpp>
-#include <stl2/detail/algorithm/find.hpp>
-
 #include <array>
 #include <iostream>
 #include <list>
@@ -25,1034 +22,974 @@
 #include <regex>
 #include <string>
 #include <vector>
-#include "../simple_test.hpp"
+#include "../catch.hpp"
 
-namespace ranges = std::experimental::ranges;
-using ranges::ext::span;
-using ranges::ext::__span::narrow_cast;
-using ranges::ext::make_span;
-using ranges::ext::as_bytes;
-using ranges::ext::as_writeable_bytes;
+// FIXME: match_results forward decl causes problems with libstdc++
+#ifdef _GLIBCXX_RELEASE
+#define NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#endif
+#include <nanorange/span.hpp>
+#include <nanorange/algorithm/find.hpp>
+
+namespace ranges = nano::ranges;
+using ranges::span;
+using ranges::as_bytes;
+using ranges::as_writable_bytes;
 
 namespace {
-	struct BaseClass {};
-	struct DerivedClass : BaseClass {};
-}
+struct BaseClass {};
+struct DerivedClass : BaseClass {};
+
+auto make_span = [](auto&&... args)
+    -> decltype(span(std::forward<decltype(args)>(args)...))
+{
+    return span(std::forward<decltype(args)>(args)...);
+};
 
 void test_case_default_constructor()
 {
-	{
-		span<int> s;
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int> s;
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int> cs;
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int> cs;
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 
-	{
-		span<int, 0> s;
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int, 0> s;
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int, 0> cs;
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int, 0> cs;
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 
-	{
-		span<int, 1> s;
-		CHECK((s.size() == 1 && s.data() == nullptr));
-	}
+    {
+//        span<int, 1> s;
+//        CHECK((s.size() == 1 && s.data() == nullptr));
+    }
 
-	{
-		span<int> s{};
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int> s{};
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int> cs{};
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int> cs{};
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 }
 
 void test_case_size_optimization()
 {
-	{
-		span<int> s;
-		CHECK(sizeof(s) == sizeof(int*) + sizeof(std::ptrdiff_t));
-	}
+    {
+        span<int> s;
+        CHECK(sizeof(s) == sizeof(int*) + sizeof(std::ptrdiff_t));
+    }
 
-	{
-		span<int, 0> s;
-		CHECK(sizeof(s) == sizeof(int*));
-	}
+    {
+        span<int, 0> s;
+        CHECK(sizeof(s) == sizeof(int*));
+    }
 }
 
 void test_case_from_nullptr_constructor()
 {
-	// This implementation doesn't support the silly nullptr_t constructor.
-	static_assert(!std::is_constructible<span<int>, std::nullptr_t>::value);
-	static_assert(!std::is_constructible<span<const int>, std::nullptr_t>::value);
+    // This implementation doesn't support the silly nullptr_t constructor.
+    static_assert(!std::is_constructible<span<int>, std::nullptr_t>::value);
+    static_assert(
+        !std::is_constructible<span<const int>, std::nullptr_t>::value);
 
-	static_assert(!std::is_constructible<span<int, 0>, std::nullptr_t>::value);
-	static_assert(!std::is_constructible<span<const int, 0>, std::nullptr_t>::value);
+    static_assert(!std::is_constructible<span<int, 0>, std::nullptr_t>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 0>, std::nullptr_t>::value);
 
-	static_assert(!std::is_constructible<span<int, 1>, std::nullptr_t>::value);
-	static_assert(!std::is_constructible<span<const int, 1>, std::nullptr_t>::value);
+    static_assert(!std::is_constructible<span<int, 1>, std::nullptr_t>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 1>, std::nullptr_t>::value);
 }
 
 void test_case_from_nullptr_size_constructor()
 {
-	{
-		span<int> s{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int> s{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int> cs{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int> cs{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 
-	{
-		span<int, 0> s{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int, 0> s{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int, 0> cs{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int, 0> cs{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 
-	{
-		span<int*> s{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((s.size() == 0 && s.data() == nullptr));
+    {
+        span<int*> s{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((s.size() == 0 && s.data() == nullptr));
 
-		span<const int*> cs{nullptr, static_cast<span<int>::index_type>(0)};
-		CHECK((cs.size() == 0 && cs.data() == nullptr));
-	}
+        span<const int*> cs{nullptr, static_cast<span<int>::index_type>(0)};
+        CHECK((cs.size() == 0 && cs.data() == nullptr));
+    }
 }
 
 void test_case_from_pointer_size_constructor()
 {
-	int arr[4] = {1, 2, 3, 4};
+    int arr[4] = {1, 2, 3, 4};
 
-	{
-		span<int> s{&arr[0], 2};
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        span<int> s{&arr[0], 2};
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		span<int, 2> s{&arr[0], 2};
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        span<int, 2> s{&arr[0], 2};
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		int* p = nullptr;
-		span<int> s{p, static_cast<span<int>::index_type>(0)};
-		CHECK((s.size() == 0 && s.data() == nullptr));
-	}
+    {
+        int* p = nullptr;
+        span<int> s{p, static_cast<span<int>::index_type>(0)};
+        CHECK((s.size() == 0 && s.data() == nullptr));
+    }
 
-	{
-		auto s = make_span(&arr[0], 2);
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        auto s = make_span(&arr[0], 2);
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		int* p = nullptr;
-		auto s = make_span(p, static_cast<span<int>::index_type>(0));
-		CHECK((s.size() == 0 && s.data() == nullptr));
-	}
-
-	{
-		int i = 42;
-		span<int> s{&i, 0};
-		CHECK((s.size() == 0 && s.data() == &i));
-
-		span<const int> cs{&i, 0};
-		CHECK((s.size() == 0 && s.data() == &i));
-	}
+    {
+        int* p = nullptr;
+        auto s = make_span(p, static_cast<span<int>::index_type>(0));
+        CHECK((s.size() == 0 && s.data() == nullptr));
+    }
 }
 
 void test_case_from_pointer_pointer_constructor()
 {
-	int arr[4] = {1, 2, 3, 4};
+    int arr[4] = {1, 2, 3, 4};
 
-	{
-		span<int> s{&arr[0], &arr[2]};
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        span<int> s{&arr[0], &arr[2]};
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		span<int, 2> s{&arr[0], &arr[2]};
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        span<int, 2> s{&arr[0], &arr[2]};
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		span<int> s{&arr[0], &arr[0]};
-		CHECK((s.size() == 0 && s.data() == &arr[0]));
-	}
+    {
+        span<int> s{&arr[0], &arr[0]};
+        CHECK((s.size() == 0 && s.data() == &arr[0]));
+    }
 
-	{
-		span<int, 0> s{&arr[0], &arr[0]};
-		CHECK((s.size() == 0 && s.data() == &arr[0]));
-	}
+    {
+        span<int, 0> s{&arr[0], &arr[0]};
+        CHECK((s.size() == 0 && s.data() == &arr[0]));
+    }
 
-	// this will fail the std::distance() precondition, which asserts on MSVC debug builds
-	//{
-	//    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
-	//    CHECK_THROWS_AS(workaround_macro(), fail_fast);
-	//}
+    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
+    //{
+    //    auto workaround_macro = [&]() { span<int> s{&arr[1], &arr[0]}; };
+    //    CHECK_THROWS_AS(workaround_macro(), fail_fast);
+    //}
 
-	// this will fail the std::distance() precondition, which asserts on MSVC debug builds
-	//{
-	//    int* p = nullptr;
-	//    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-	//    CHECK_THROWS_AS(workaround_macro(), fail_fast);
-	//}
+    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
+    //{
+    //    int* p = nullptr;
+    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+    //    CHECK_THROWS_AS(workaround_macro(), fail_fast);
+    //}
 
-	{
-		int* p = nullptr;
-		span<int> s{p, p};
-		CHECK((s.size() == 0 && s.data() == nullptr));
-	}
+    {
+        int* p = nullptr;
+        span<int> s{p, p};
+        CHECK((s.size() == 0 && s.data() == nullptr));
+    }
 
-	{
-		int* p = nullptr;
-		span<int, 0> s{p, p};
-		CHECK((s.size() == 0 && s.data() == nullptr));
-	}
+    {
+        int* p = nullptr;
+        span<int, 0> s{p, p};
+        CHECK((s.size() == 0 && s.data() == nullptr));
+    }
 
-	// this will fail the std::distance() precondition, which asserts on MSVC debug builds
-	//{
-	//    int* p = nullptr;
-	//    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
-	//    CHECK_THROWS_AS(workaround_macro(), fail_fast);
-	//}
+    // this will fail the std::distance() precondition, which asserts on MSVC debug builds
+    //{
+    //    int* p = nullptr;
+    //    auto workaround_macro = [&]() { span<int> s{&arr[0], p}; };
+    //    CHECK_THROWS_AS(workaround_macro(), fail_fast);
+    //}
 
-	{
-		auto s = make_span(&arr[0], &arr[2]);
-		CHECK((s.size() == 2 && s.data() == &arr[0]));
-		CHECK((s[0] == 1 && s[1] == 2));
-	}
+    {
+        auto s = make_span(&arr[0], &arr[2]);
+        CHECK((s.size() == 2 && s.data() == &arr[0]));
+        CHECK((s[0] == 1 && s[1] == 2));
+    }
 
-	{
-		auto s = make_span(&arr[0], &arr[0]);
-		CHECK((s.size() == 0 && s.data() == &arr[0]));
-	}
+    {
+        auto s = make_span(&arr[0], &arr[0]);
+        CHECK((s.size() == 0 && s.data() == &arr[0]));
+    }
 
-	{
-		int* p = nullptr;
-		auto s = make_span(p, p);
-		CHECK((s.size() == 0 && s.data() == nullptr));
-	}
+    {
+        int* p = nullptr;
+        auto s = make_span(p, p);
+        CHECK((s.size() == 0 && s.data() == nullptr));
+    }
 }
 
 void test_case_from_array_constructor()
 {
-	int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-	{
-		span<int> s{arr};
-		CHECK((s.size() == 5 && s.data() == &arr[0]));
-	}
+    {
+        span<int> s{arr};
+        CHECK((s.size() == 5 && s.data() == &arr[0]));
+    }
 
-	{
-		span<int, 5> s{arr};
-		CHECK((s.size() == 5 && s.data() == &arr[0]));
-	}
+    {
+        span<int, 5> s{arr};
+        CHECK((s.size() == 5 && s.data() == &arr[0]));
+    }
 
-	int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
+    int arr2d[2][3] = {1, 2, 3, 4, 5, 6};
 
-	static_assert(!std::is_constructible<span<int, 6>, int(&)[5]>::value);
-	static_assert(!std::is_constructible<span<int, 0>, int(&)[5]>::value);
-	static_assert(!std::is_constructible<span<int>, decltype((arr2d))>::value);
-	static_assert(!std::is_constructible<span<int, 0>, decltype((arr2d))>::value);
-	static_assert(!std::is_constructible<span<int, 6>, decltype((arr2d))>::value);
+    static_assert(!std::is_constructible<span<int, 6>, int(&)[5]>::value);
+    static_assert(!std::is_constructible<span<int, 0>, int(&)[5]>::value);
+    static_assert(!std::is_constructible<span<int>, decltype((arr2d))>::value);
+    static_assert(
+        !std::is_constructible<span<int, 0>, decltype((arr2d))>::value);
+    static_assert(
+        !std::is_constructible<span<int, 6>, decltype((arr2d))>::value);
 
-	{
-		span<int[3]> s{&(arr2d[0]), 1};
-		CHECK((s.size() == 1 && s.data() == &arr2d[0]));
-	}
+    {
+        span<int[3]> s{&(arr2d[0]), 1};
+        CHECK((s.size() == 1 && s.data() == &arr2d[0]));
+    }
 
-	int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    int arr3d[2][3][2] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-	static_assert(!std::is_constructible<span<int>, decltype((arr3d))>::value);
-	static_assert(!std::is_constructible<span<int, 0>, decltype((arr3d))>::value);
-	static_assert(!std::is_constructible<span<int, 11>, decltype((arr3d))>::value);
-	static_assert(!std::is_constructible<span<int, 12>, decltype((arr3d))>::value);
+    static_assert(!std::is_constructible<span<int>, decltype((arr3d))>::value);
+    static_assert(
+        !std::is_constructible<span<int, 0>, decltype((arr3d))>::value);
+    static_assert(
+        !std::is_constructible<span<int, 11>, decltype((arr3d))>::value);
+    static_assert(
+        !std::is_constructible<span<int, 12>, decltype((arr3d))>::value);
 
-	{
-		span<int[3][2]> s{&arr3d[0], 1};
-		CHECK((s.size() == 1 && s.data() == &arr3d[0]));
-	}
+    {
+        span<int[3][2]> s{&arr3d[0], 1};
+        CHECK((s.size() == 1 && s.data() == &arr3d[0]));
+    }
 
-	{
-		auto s = make_span(arr);
-		CHECK((s.size() == 5 && s.data() == &arr[0]));
-	}
+    {
+        auto s = make_span(arr);
+        CHECK((s.size() == 5 && s.data() == &arr[0]));
+    }
 
-	{
-		auto s = make_span(&(arr2d[0]), 1);
-		CHECK((s.size() == 1 && s.data() == &arr2d[0]));
-	}
+    {
+        auto s = make_span(&(arr2d[0]), 1);
+        CHECK((s.size() == 1 && s.data() == &arr2d[0]));
+    }
 
-	{
-		auto s = make_span(&arr3d[0], 1);
-		CHECK((s.size() == 1 && s.data() == &arr3d[0]));
-	}
+    {
+        auto s = make_span(&arr3d[0], 1);
+        CHECK((s.size() == 1 && s.data() == &arr3d[0]));
+    }
 }
 
 void test_case_from_std_array_constructor()
 {
-	std::array<int, 4> arr = {1, 2, 3, 4};
+    std::array<int, 4> arr = {1, 2, 3, 4};
 
-	{
-		span<int> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
+    {
+        span<int> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
 
-		span<const int> cs{arr};
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && cs.data() == arr.data()));
-	}
+        span<const int> cs{arr};
+        CHECK((cs.size() == arr.size() &&
+               cs.data() == arr.data()));
+    }
 
-	{
-		span<int, 4> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
+    {
+        span<int, 4> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
 
-		span<const int, 4> cs{arr};
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && cs.data() == arr.data()));
-	}
+        span<const int, 4> cs{arr};
+        CHECK((cs.size() == arr.size() &&
+               cs.data() == arr.data()));
+    }
 
-	static_assert(!std::is_constructible<span<int, 2>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 2>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<int, 0>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 0>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<int, 5>, decltype((arr))>::value);
+    static_assert(!std::is_constructible<span<int, 2>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 2>, decltype((arr))>::value);
+    static_assert(!std::is_constructible<span<int, 0>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 0>, decltype((arr))>::value);
+    static_assert(!std::is_constructible<span<int, 5>, decltype((arr))>::value);
 
-	{
-		auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-		auto take_a_span = [](span<int>) {};
-		take_a_span(get_an_array());
-	}
+#if 0
+    {
+        auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
+        auto take_a_span = [](span<int>) {};
+        take_a_span(get_an_array());
+    }
+#endif
 
-	{
-		auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
-		auto take_a_span = [](span<const int>) {};
-		take_a_span(get_an_array());
-	}
+    {
+        auto get_an_array = []() -> std::array<int, 4> { return {1, 2, 3, 4}; };
+        auto take_a_span = [](span<const int>) {};
+        take_a_span(get_an_array());
+    }
 
-	{
-		auto s = make_span(arr);
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        auto s = make_span(arr);
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 }
 
 void test_case_from_const_std_array_constructor()
 {
-	const std::array<int, 4> arr = {1, 2, 3, 4};
+    const std::array<int, 4> arr = {1, 2, 3, 4};
 
-	{
-		span<const int> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        span<const int> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 
-	{
-		span<const int, 4> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        span<const int, 4> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 
-	static_assert(!std::is_constructible<span<const int, 2>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 0>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 5>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 2>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 0>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 5>, decltype((arr))>::value);
 
-	{
-		auto get_an_array = []() -> const std::array<int, 4> { return {1, 2, 3, 4}; };
-		auto take_a_span = [](span<const int>) {};
-		take_a_span(get_an_array());
-	}
+    {
+        auto get_an_array = []() -> const std::array<int, 4> {
+            return {1, 2, 3, 4};
+        };
+        auto take_a_span = [](span<const int>) {};
+        take_a_span(get_an_array());
+    }
 
-	{
-		auto s = make_span(arr);
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        auto s = make_span(arr);
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 }
-
+#if 0
 void test_case_from_std_array_const_constructor()
 {
-	std::array<const int, 4> arr = {1, 2, 3, 4};
+    std::array<const int, 4> arr = {1, 2, 3, 4};
 
-	{
-		span<const int> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        span<const int> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 
-	{
-		span<const int, 4> s{arr};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        span<const int, 4> s{arr};
+        CHECK((s.size() == arr.size() &&
+               s.data() == arr.data()));
+    }
 
-	static_assert(!std::is_constructible<span<const int, 2>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 0>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<const int, 5>, decltype((arr))>::value);
-	static_assert(!std::is_constructible<span<int, 4>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 2>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 0>, decltype((arr))>::value);
+    static_assert(
+        !std::is_constructible<span<const int, 5>, decltype((arr))>::value);
+    static_assert(!std::is_constructible<span<int, 4>, decltype((arr))>::value);
 
-	{
-		auto s = make_span(arr);
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) && s.data() == arr.data()));
-	}
+    {
+        auto s = make_span(arr);
+        CHECK((s.size() == narrow_cast<std::ptrdiff_t>(arr.size()) &&
+               s.data() == arr.data()));
+    }
 }
+#endif
 
 void test_case_from_container_constructor()
 {
-	std::vector<int> v = {1, 2, 3};
-	const std::vector<int> cv = v;
+    std::vector<int> v = {1, 2, 3};
+    const std::vector<int> cv = v;
 
-	{
-		span<int> s{v};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(v.size()) && s.data() == v.data()));
+    {
+        span<int> s{v};
+        CHECK((s.size() == v.size() &&
+               s.data() == v.data()));
 
-		span<const int> cs{v};
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(v.size()) && cs.data() == v.data()));
-	}
+        span<const int> cs{v};
+        CHECK((cs.size() == v.size() &&
+               cs.data() == v.data()));
+    }
 
-	std::string str = "hello";
-	const std::string cstr = "hello";
+    std::string str = "hello";
+    const std::string cstr = "hello";
 
-	{
-		span<char> s{str};
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(str.size()) && s.data() == str.data()));
-	}
+    {
+        span<char> s{str};
+        CHECK((s.size() == str.size() &&
+               s.data() == str.data()));
+    }
+#if 0
+    {
+        auto get_temp_string = []() -> std::string { return {}; };
+        auto use_span = [](span<char>) {};
+        use_span(get_temp_string());
+    }
+#endif
 
-	{
-		auto get_temp_string = []() -> std::string { return {}; };
-		auto use_span = [](span<char>) {};
-		use_span(get_temp_string());
-	}
+    {
+        span<const char> cs{str};
+        CHECK((cs.size() == str.size() &&
+               cs.data() == str.data()));
+    }
 
-	{
-		span<const char> cs{str};
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(str.size()) && cs.data() == str.data()));
-	}
+    {
+        auto get_temp_string = []() -> std::string { return {}; };
+        auto use_span = [](span<const char>) {};
+        use_span(get_temp_string());
+    }
 
-	{
-		auto get_temp_string = []() -> std::string { return {}; };
-		auto use_span = [](span<const char>) {};
-		use_span(get_temp_string());
-	}
+    {
+        static_assert(
+            !std::is_constructible<span<char>, decltype((cstr))>::value);
+        span<const char> cs{cstr};
+        CHECK((cs.size() == cstr.size() &&
+               cs.data() == cstr.data()));
+    }
+#if 0
+    {
+        auto get_temp_vector = []() -> std::vector<int> { return {}; };
+        auto use_span = [](span<int>) {};
+        use_span(get_temp_vector());
+    }
+#endif
 
-	{
-		static_assert(!std::is_constructible<span<char>, decltype((cstr))>::value);
-		span<const char> cs{cstr};
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(cstr.size()) &&
-			  cs.data() == cstr.data()));
-	}
+    {
+        auto get_temp_vector = []() -> std::vector<int> { return {}; };
+        auto use_span = [](span<const int>) {};
+        use_span(get_temp_vector());
+    }
 
-	{
-		auto get_temp_vector = []() -> std::vector<int> { return {}; };
-		auto use_span = [](span<int>) {};
-		use_span(get_temp_vector());
-	}
+    static_assert(
+        !std::is_convertible<const std::vector<int>, span<const char>>::value);
 
-	{
-		auto get_temp_vector = []() -> std::vector<int> { return {}; };
-		auto use_span = [](span<const int>) {};
-		use_span(get_temp_vector());
-	}
+    {
+        auto get_temp_string = []() -> const std::string { return {}; };
+        auto use_span = [](span<const char> s) { static_cast<void>(s); };
+        use_span(get_temp_string());
+        use_span(span<const char>(get_temp_string()));
+    }
 
-	static_assert(!std::is_convertible<const std::vector<int>, span<const char>>::value);
+    static_assert(
+        !std::is_constructible<span<int>, std::map<int, int>&>::value);
 
-	{
-		auto get_temp_string = []() -> const std::string { return {}; };
-		auto use_span = [](span<const char> s) { static_cast<void>(s); };
-		use_span(get_temp_string());
-		use_span(span<const char>(get_temp_string()));
-	}
+    {
+        auto s = make_span(v);
+        CHECK((s.size() == v.size() &&
+               s.data() == v.data()));
 
-	static_assert(!std::is_constructible<span<int>, std::map<int, int>&>::value);
-
-	{
-		auto s = make_span(v);
-		CHECK((s.size() == narrow_cast<std::ptrdiff_t>(v.size()) && s.data() == v.data()));
-
-		auto cs = make_span(cv);
-		CHECK((cs.size() == narrow_cast<std::ptrdiff_t>(cv.size()) && cs.data() == cv.data()));
-	}
+        auto cs = make_span(cv);
+        CHECK((cs.size() == cv.size() &&
+               cs.data() == cv.data()));
+    }
 }
 
 void test_case_from_convertible_span_constructor()
 {
-	{
-		span<DerivedClass> avd;
-		span<const DerivedClass> avcd = avd;
-		static_cast<void>(avcd);
-	}
+    {
+        span<DerivedClass> avd;
+        span<const DerivedClass> avcd = avd;
+        static_cast<void>(avcd);
+    }
 
-	static_assert(!std::is_constructible<span<BaseClass>, span<DerivedClass>>::value);
-	static_assert(!std::is_constructible<span<DerivedClass>, span<BaseClass>>::value);
-	static_assert(!std::is_constructible<span<unsigned int>, span<int>>::value);
-	static_assert(!std::is_constructible<span<const unsigned int>, span<int>>::value);
-	static_assert(!std::is_constructible<span<short>, span<int>>::value);
+    static_assert(
+        !std::is_constructible<span<BaseClass>, span<DerivedClass>>::value);
+    static_assert(
+        !std::is_constructible<span<DerivedClass>, span<BaseClass>>::value);
+    static_assert(!std::is_constructible<span<unsigned int>, span<int>>::value);
+    static_assert(
+        !std::is_constructible<span<const unsigned int>, span<int>>::value);
+    static_assert(!std::is_constructible<span<short>, span<int>>::value);
 }
 
 void test_case_copy_move_and_assignment()
 {
-	span<int> s1;
-	CHECK(s1.empty());
+    span<int> s1;
+    CHECK(s1.empty());
 
-	int arr[] = {3, 4, 5};
+    int arr[] = {3, 4, 5};
 
-	span<const int> s2 = arr;
-	CHECK((s2.size() == 3 && s2.data() == &arr[0]));
+    span<const int> s2 = arr;
+    CHECK((s2.size() == 3 && s2.data() == &arr[0]));
 
-	s2 = s1;
-	CHECK(s2.empty());
+    s2 = s1;
+    CHECK(s2.empty());
 
-	auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
-	auto use_span = [&](span<const int> s) { CHECK((s.size() == 2 && s.data() == &arr[1])); };
-	use_span(get_temp_span());
+    auto get_temp_span = [&]() -> span<int> { return {&arr[1], 2}; };
+    auto use_span = [&](span<const int> s) {
+        CHECK((s.size() == 2 && s.data() == &arr[1]));
+    };
+    use_span(get_temp_span());
 
-	s1 = get_temp_span();
-	CHECK((s1.size() == 2 && s1.data() == &arr[1]));
+    s1 = get_temp_span();
+    CHECK((s1.size() == 2 && s1.data() == &arr[1]));
 }
 
 void test_case_class_template_argument_deduction()
 {
 #ifdef __cpp_deduction_guides
-	{
-		int arr[] = {1, 2, 3, 4, 5};
-		{
-			span s{arr};
-			static_assert(ranges::Same<span<int, 5>, decltype(s)>);
-		}
+    {
+        int arr[] = {1, 2, 3, 4, 5};
+        {
+            span s{arr};
+            static_assert(ranges::same_as<span<int, 5>, decltype(s)>);
+        }
+        {
+            span s{ranges::begin(arr), ranges::size(arr)};
+            static_assert(ranges::same_as<span<int>, decltype(s)>);
+        }
+        {
+            span s{ranges::begin(arr), ranges::end(arr)};
+            static_assert(ranges::same_as<span<int>, decltype(s)>);
+        }
+    }
+    {
+        std::array<int, 5> arr = {1, 2, 3, 4, 5};
+        {
+            span s{arr};
+            static_assert(ranges::same_as<span<int, 5>, decltype(s)>);
+        }
+#if 0 // TODO: reactivate these cases on the span_updates branch
 		{
 			span s{ranges::begin(arr), ranges::size(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
 		{
 			span s{ranges::begin(arr), ranges::end(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
+			static_assert(ranges::same_as<span<int>, decltype(s)>);
 		}
-	}
-	{
-		std::array<int, 5> arr = {1, 2, 3, 4, 5};
-		{
-			span s{arr};
-			static_assert(ranges::Same<span<int, 5>, decltype(s)>);
-		}
-		{
-			span s{ranges::begin(arr), ranges::size(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
-		}
-		{
-			span s{ranges::begin(arr), ranges::end(arr)};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
-		}
-	}
-	{
-		std::vector<int> vec = {1, 2, 3, 4, 5};
-		{
-			span s{vec};
-			static_assert(ranges::Same<span<int>, decltype(s)>);
-		}
-	}
+#endif
+    }
+    {
+        std::vector<int> vec = {1, 2, 3, 4, 5};
+        {
+            span s{vec};
+            static_assert(ranges::same_as<span<int>, decltype(s)>);
+        }
+    }
 #endif
 }
 
 void test_case_first()
 {
-	int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.first<2>().size() == 2);
-		CHECK(av.first(2).size() == 2);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.first<2>().size() == 2);
+        CHECK(av.first(2).size() == 2);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.first<0>().size() == 0);
-		CHECK(av.first(0).size() == 0);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.first<0>().size() == 0);
+        CHECK(av.first(0).size() == 0);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.first<5>().size() == 5);
-		CHECK(av.first(5).size() == 5);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.first<5>().size() == 5);
+        CHECK(av.first(5).size() == 5);
+    }
 
-	{
-		span<int> av;
-		CHECK(av.first<0>().size() == 0);
-		CHECK(av.first(0).size() == 0);
-	}
+    {
+        span<int> av;
+        CHECK(av.first<0>().size() == 0);
+        CHECK(av.first(0).size() == 0);
+    }
 }
 
 void test_case_last()
 {
-	int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.last<2>().size() == 2);
-		CHECK(av.last(2).size() == 2);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<2>().size() == 2);
+        CHECK(av.last(2).size() == 2);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.last<0>().size() == 0);
-		CHECK(av.last(0).size() == 0);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<0>().size() == 0);
+        CHECK(av.last(0).size() == 0);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.last<5>().size() == 5);
-		CHECK(av.last(5).size() == 5);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.last<5>().size() == 5);
+        CHECK(av.last(5).size() == 5);
+    }
 
-	{
-		span<int> av;
-		CHECK(av.last<0>().size() == 0);
-		CHECK(av.last(0).size() == 0);
-	}
+    {
+        span<int> av;
+        CHECK(av.last<0>().size() == 0);
+        CHECK(av.last(0).size() == 0);
+    }
 }
 
 void test_case_subspan()
 {
-	int arr[5] = {1, 2, 3, 4, 5};
+    int arr[5] = {1, 2, 3, 4, 5};
 
-	{
-		span<int, 5> av = arr;
-		CHECK((av.subspan<2, 2>().size() == 2));
-		CHECK(av.subspan(2, 2).size() == 2);
-		CHECK(av.subspan(2, 3).size() == 3);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<2, 2>().size() == 2));
+        CHECK(av.subspan(2, 2).size() == 2);
+        CHECK(av.subspan(2, 3).size() == 3);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK((av.subspan<0, 0>().size() == 0));
-		CHECK(av.subspan(0, 0).size() == 0);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<0, 0>().size() == 0));
+        CHECK(av.subspan(0, 0).size() == 0);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK((av.subspan<0, 5>().size() == 5));
-		CHECK(av.subspan(0, 5).size() == 5);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<0, 5>().size() == 5));
+        CHECK(av.subspan(0, 5).size() == 5);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK((av.subspan<4, 0>().size() == 0));
-		CHECK(av.subspan(4, 0).size() == 0);
-		CHECK(av.subspan(5, 0).size() == 0);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK((av.subspan<4, 0>().size() == 0));
+        CHECK(av.subspan(4, 0).size() == 0);
+        CHECK(av.subspan(5, 0).size() == 0);
+    }
 
-	{
-		span<int> av;
-		CHECK((av.subspan<0, 0>().size() == 0));
-		CHECK(av.subspan(0, 0).size() == 0);
-	}
+    {
+        span<int> av;
+        CHECK((av.subspan<0, 0>().size() == 0));
+        CHECK(av.subspan(0, 0).size() == 0);
+    }
 
-	{
-		span<int> av;
-		CHECK(av.subspan(0).size() == 0);
-	}
+    {
+        span<int> av;
+        CHECK(av.subspan(0).size() == 0);
+    }
 
-	{
-		span<int> av = arr;
-		CHECK(av.subspan(0).size() == 5);
-		CHECK(av.subspan(1).size() == 4);
-		CHECK(av.subspan(4).size() == 1);
-		CHECK(av.subspan(5).size() == 0);
-		const auto av2 = av.subspan(1);
-		for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
-	}
+    {
+        span<int> av = arr;
+        CHECK(av.subspan(0).size() == 5);
+        CHECK(av.subspan(1).size() == 4);
+        CHECK(av.subspan(4).size() == 1);
+        CHECK(av.subspan(5).size() == 0);
+        const auto av2 = av.subspan(1);
+        for (int i = 0; i < 4; ++i)
+            CHECK(av2[i] == i + 2);
+    }
 
-	{
-		span<int, 5> av = arr;
-		CHECK(av.subspan(0).size() == 5);
-		CHECK(av.subspan(1).size() == 4);
-		CHECK(av.subspan(4).size() == 1);
-		CHECK(av.subspan(5).size() == 0);
-		const auto av2 = av.subspan(1);
-		for (int i = 0; i < 4; ++i) CHECK(av2[i] == i + 2);
-	}
+    {
+        span<int, 5> av = arr;
+        CHECK(av.subspan(0).size() == 5);
+        CHECK(av.subspan(1).size() == 4);
+        CHECK(av.subspan(4).size() == 1);
+        CHECK(av.subspan(5).size() == 0);
+        const auto av2 = av.subspan(1);
+        for (int i = 0; i < 4; ++i)
+            CHECK(av2[i] == i + 2);
+    }
 }
 
 void test_case_iterator_value_init()
 {
-	span<int>::iterator it1{};
-	span<int>::iterator it2{};
-	CHECK(it1 == it2);
+    span<int>::iterator it1{};
+    span<int>::iterator it2{};
+    CHECK(it1 == it2);
 }
 
 void test_case_iterator_comparisons()
 {
-	int a[] = {1, 2, 3, 4};
-	{
-		span<int> s = a;
-		span<int>::iterator it = s.begin();
-		auto it2 = it + 1;
+    int a[] = {1, 2, 3, 4};
+    {
+        span<int> s = a;
+        span<int>::iterator it = s.begin();
+        auto it2 = it + 1;
 
-		CHECK(it == it);
-		CHECK(it == s.begin());
-		CHECK(s.begin() == it);
+        CHECK(it == it);
+        CHECK(it == s.begin());
+        CHECK(s.begin() == it);
 
-		CHECK(it != it2);
-		CHECK(it2 != it);
-		CHECK(it != s.end());
-		CHECK(it2 != s.end());
-		CHECK(s.end() != it);
+        CHECK(it != it2);
+        CHECK(it2 != it);
+        CHECK(it != s.end());
+        CHECK(it2 != s.end());
+        CHECK(s.end() != it);
 
-		CHECK(it < it2);
-		CHECK(it <= it2);
-		CHECK(it2 <= s.end());
-		CHECK(it < s.end());
+        CHECK(it < it2);
+        CHECK(it <= it2);
+        CHECK(it2 <= s.end());
+        CHECK(it < s.end());
 
-		CHECK(it2 > it);
-		CHECK(it2 >= it);
-		CHECK(s.end() > it2);
-		CHECK(s.end() >= it2);
-	}
+        CHECK(it2 > it);
+        CHECK(it2 >= it);
+        CHECK(s.end() > it2);
+        CHECK(s.end() >= it2);
+    }
 }
 
 void test_case_begin_end()
 {
-	{
-		int a[] = {1, 2, 3, 4};
-		span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-		span<int>::iterator it = s.begin();
-		span<int>::iterator it2 = std::begin(s);
-		CHECK(it == it2);
+        span<int>::iterator it = s.begin();
+        span<int>::iterator it2 = std::begin(s);
+        CHECK(it == it2);
 
-		it = s.end();
-		it2 = std::end(s);
-		CHECK(it == it2);
-	}
+        it = s.end();
+        it2 = std::end(s);
+        CHECK(it == it2);
+    }
 
-	{
-		int a[] = {1, 2, 3, 4};
-		span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-		auto it = s.begin();
-		auto first = it;
-		CHECK(it == first);
-		CHECK(*it == 1);
+        auto it = s.begin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 1);
 
-		auto beyond = s.end();
-		CHECK(it != beyond);
+        auto beyond = s.end();
+        CHECK(it != beyond);
 
-		CHECK((beyond - first) == 4);
-		CHECK((first - first) == 0);
-		CHECK((beyond - beyond) == 0);
+        CHECK((beyond - first) == 4);
+        CHECK((first - first) == 0);
+        CHECK((beyond - beyond) == 0);
 
-		++it;
-		CHECK((it - first) == 1);
-		CHECK(*it == 2);
-		*it = 22;
-		CHECK(*it == 22);
-		CHECK((beyond - it) == 3);
+        ++it;
+        CHECK((it - first) == 1);
+        CHECK(*it == 2);
+        *it = 22;
+        CHECK(*it == 22);
+        CHECK((beyond - it) == 3);
 
-		it = first;
-		CHECK(it == first);
-		while (it != s.end()) {
-			*it = 5;
-			++it;
-		}
+        it = first;
+        CHECK(it == first);
+        while (it != s.end()) {
+            *it = 5;
+            ++it;
+        }
 
-		CHECK(it == beyond);
-		CHECK((it - beyond) == 0);
+        CHECK(it == beyond);
+        CHECK((it - beyond) == 0);
 
-		for (const auto& n : s) {
-			CHECK(n == 5);
-		}
-	}
+        for (const auto& n : s) {
+            CHECK(n == 5);
+        }
+    }
 }
 
 void test_case_rbegin_rend()
 {
-	{
-		int a[] = {1, 2, 3, 4};
-		span<int> s = a;
+    {
+        int a[] = {1, 2, 3, 4};
+        span<int> s = a;
 
-		auto it = s.rbegin();
-		auto first = it;
-		CHECK(it == first);
-		CHECK(*it == 4);
+        auto it = s.rbegin();
+        auto first = it;
+        CHECK(it == first);
+        CHECK(*it == 4);
 
-		auto beyond = s.rend();
-		CHECK(it != beyond);
+        auto beyond = s.rend();
+        CHECK(it != beyond);
 
-		CHECK((beyond - first) == 4);
-		CHECK((first - first) == 0);
-		CHECK((beyond - beyond) == 0);
+        CHECK((beyond - first) == 4);
+        CHECK((first - first) == 0);
+        CHECK((beyond - beyond) == 0);
 
-		++it;
-		CHECK((it - first) == 1);
-		CHECK(*it == 3);
-		*it = 22;
-		CHECK(*it == 22);
-		CHECK((beyond - it) == 3);
+        ++it;
+        CHECK((it - first) == 1);
+        CHECK(*it == 3);
+        *it = 22;
+        CHECK(*it == 22);
+        CHECK((beyond - it) == 3);
 
-		it = first;
-		CHECK(it == first);
-		while (it != s.rend()) {
-			*it = 5;
-			++it;
-		}
+        it = first;
+        CHECK(it == first);
+        while (it != s.rend()) {
+            *it = 5;
+            ++it;
+        }
 
-		CHECK(it == beyond);
-		CHECK((it - beyond) == 0);
+        CHECK(it == beyond);
+        CHECK((it - beyond) == 0);
 
-		for (const auto& n : s) {
-			CHECK(n == 5);
-		}
-	}
-}
-
-void test_case_comparison_operators()
-{
-	{
-		span<int> s1;
-		span<int> s2;
-		CHECK(s1 == s2);
-		CHECK(!(s1 != s2));
-		CHECK(!(s1 < s2));
-		CHECK(s1 <= s2);
-		CHECK(!(s1 > s2));
-		CHECK(s1 >= s2);
-		CHECK(s2 == s1);
-		CHECK(!(s2 != s1));
-		CHECK(!(s2 < s1));
-		CHECK(s2 <= s1);
-		CHECK(!(s2 > s1));
-		CHECK(s2 >= s1);
-	}
-
-	{
-		int arr[] = {2, 1};
-		span<int> s1 = arr;
-		span<int> s2 = arr;
-
-		CHECK(s1 == s2);
-		CHECK(!(s1 != s2));
-		CHECK(!(s1 < s2));
-		CHECK(s1 <= s2);
-		CHECK(!(s1 > s2));
-		CHECK(s1 >= s2);
-		CHECK(s2 == s1);
-		CHECK(!(s2 != s1));
-		CHECK(!(s2 < s1));
-		CHECK(s2 <= s1);
-		CHECK(!(s2 > s1));
-		CHECK(s2 >= s1);
-	}
-
-	{
-		int arr[] = {2, 1}; // bigger
-
-		span<int> s1;
-		span<int> s2 = arr;
-
-		CHECK(s1 != s2);
-		CHECK(s2 != s1);
-		CHECK(!(s1 == s2));
-		CHECK(!(s2 == s1));
-		CHECK(s1 < s2);
-		CHECK(!(s2 < s1));
-		CHECK(s1 <= s2);
-		CHECK(!(s2 <= s1));
-		CHECK(s2 > s1);
-		CHECK(!(s1 > s2));
-		CHECK(s2 >= s1);
-		CHECK(!(s1 >= s2));
-	}
-
-	{
-		int arr1[] = {1, 2};
-		int arr2[] = {1, 2};
-		span<int> s1 = arr1;
-		span<int> s2 = arr2;
-
-		CHECK(s1 == s2);
-		CHECK(!(s1 != s2));
-		CHECK(!(s1 < s2));
-		CHECK(s1 <= s2);
-		CHECK(!(s1 > s2));
-		CHECK(s1 >= s2);
-		CHECK(s2 == s1);
-		CHECK(!(s2 != s1));
-		CHECK(!(s2 < s1));
-		CHECK(s2 <= s1);
-		CHECK(!(s2 > s1));
-		CHECK(s2 >= s1);
-	}
-
-	{
-		int arr[] = {1, 2, 3};
-
-		span<int> s1 = {&arr[0], 2}; // shorter
-		span<int> s2 = arr;          // longer
-
-		CHECK(s1 != s2);
-		CHECK(s2 != s1);
-		CHECK(!(s1 == s2));
-		CHECK(!(s2 == s1));
-		CHECK(s1 < s2);
-		CHECK(!(s2 < s1));
-		CHECK(s1 <= s2);
-		CHECK(!(s2 <= s1));
-		CHECK(s2 > s1);
-		CHECK(!(s1 > s2));
-		CHECK(s2 >= s1);
-		CHECK(!(s1 >= s2));
-	}
-
-	{
-		int arr1[] = {1, 2}; // smaller
-		int arr2[] = {2, 1}; // bigger
-
-		span<int> s1 = arr1;
-		span<int> s2 = arr2;
-
-		CHECK(s1 != s2);
-		CHECK(s2 != s1);
-		CHECK(!(s1 == s2));
-		CHECK(!(s2 == s1));
-		CHECK(s1 < s2);
-		CHECK(!(s2 < s1));
-		CHECK(s1 <= s2);
-		CHECK(!(s2 <= s1));
-		CHECK(s2 > s1);
-		CHECK(!(s1 > s2));
-		CHECK(s2 >= s1);
-		CHECK(!(s1 >= s2));
-	}
+        for (const auto& n : s) {
+            CHECK(n == 5);
+        }
+    }
 }
 
 void test_case_as_bytes()
 {
-	int a[] = {1, 2, 3, 4};
+    int a[] = {1, 2, 3, 4};
 
-	{
-		const span<const int> s = a;
-		CHECK(s.size() == 4);
-		const auto bs = as_bytes(s);
-		CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-		CHECK(bs.size() == s.size_bytes());
-	}
+    {
+        const span<const int> s = a;
+        CHECK(s.size() == 4);
+        const auto bs = as_bytes(s);
+        CHECK(static_cast<const void*>(bs.data()) ==
+              static_cast<const void*>(s.data()));
+        CHECK(bs.size() == s.size_bytes());
+    }
 
-	{
-		span<int> s;
-		const auto bs = as_bytes(s);
-		CHECK(bs.size() == s.size());
-		CHECK(bs.size() == 0);
-		CHECK(bs.size_bytes() == 0);
-		CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-		CHECK(bs.data() == nullptr);
-	}
+    {
+        span<int> s;
+        const auto bs = as_bytes(s);
+        CHECK(bs.size() == s.size());
+        CHECK(bs.size() == 0);
+        CHECK(bs.size_bytes() == 0);
+        CHECK(static_cast<const void*>(bs.data()) ==
+              static_cast<const void*>(s.data()));
+        CHECK(bs.data() == nullptr);
+    }
 
-	{
-		span<int> s = a;
-		const auto bs = as_bytes(s);
-		CHECK(static_cast<const void*>(bs.data()) == static_cast<const void*>(s.data()));
-		CHECK(bs.size() == s.size_bytes());
-	}
+    {
+        span<int> s = a;
+        const auto bs = as_bytes(s);
+        CHECK(static_cast<const void*>(bs.data()) ==
+              static_cast<const void*>(s.data()));
+        CHECK(bs.size() == s.size_bytes());
+    }
 }
 
 void test_case_as_writeable_bytes()
 {
-	int a[] = {1, 2, 3, 4};
+    int a[] = {1, 2, 3, 4};
 
-	{
-		span<int> s;
-		const auto bs = as_writeable_bytes(s);
-		CHECK(bs.size() == s.size());
-		CHECK(bs.size() == 0);
-		CHECK(bs.size_bytes() == 0);
-		CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-		CHECK(bs.data() == nullptr);
-	}
+    {
+        span<int> s;
+        const auto bs = as_writable_bytes(s);
+        CHECK(bs.size() == s.size());
+        CHECK(bs.size() == 0);
+        CHECK(bs.size_bytes() == 0);
+        CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        CHECK(bs.data() == nullptr);
+    }
 
-	{
-		span<int> s = a;
-		const auto bs = as_writeable_bytes(s);
-		CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
-		CHECK(bs.size() == s.size_bytes());
-	}
+    {
+        span<int> s = a;
+        const auto bs = as_writable_bytes(s);
+        CHECK(static_cast<void*>(bs.data()) == static_cast<void*>(s.data()));
+        CHECK(bs.size() == s.size_bytes());
+    }
 }
 
 void test_case_fixed_size_conversions()
 {
-	int arr[] = {1, 2, 3, 4};
+    int arr[] = {1, 2, 3, 4};
 
-	// converting to an span from an equal size array is ok
-	span<int, 4> s4 = arr;
-	CHECK(s4.size() == 4);
+    // converting to an span from an equal size array is ok
+    span<int, 4> s4 = arr;
+    CHECK(s4.size() == 4);
 
-	// converting to dynamic_range is always ok
-	{
-		span<int> s = s4;
-		CHECK(s.size() == s4.size());
-		static_cast<void>(s);
-	}
+    // converting to dynamic_range is always ok
+    {
+        span<int> s = s4;
+        CHECK(s.size() == s4.size());
+        static_cast<void>(s);
+    }
 
-	// initialization or assignment to static span that REDUCES size is NOT ok
-	static_assert(!std::is_convertible<decltype((arr)), span<int, 2>>::value);
-	static_assert(!std::is_convertible<span<int, 4>, span<int, 2>>::value);
+    // initialization or assignment to static span that REDUCES size is NOT ok
+    static_assert(!std::is_convertible<decltype((arr)), span<int, 2>>::value);
+    static_assert(!std::is_convertible<span<int, 4>, span<int, 2>>::value);
 
-	// you can convert statically
-	{
-		const span<int, 2> s2 = {arr, 2};
-		static_cast<void>(s2);
-	}
-	{
-		const span<int, 1> s1 = s4.first<1>();
-		static_cast<void>(s1);
-	}
+    // you can convert statically
+    {
+        const span<int, 2> s2 = {arr, 2};
+        static_cast<void>(s2);
+    }
+    {
+        const span<int, 1> s1 = s4.first<1>();
+        static_cast<void>(s1);
+    }
 
-	// ...or dynamically
-	{
-		// NB: implicit conversion to span<int,1> from span<int>
-		span<int, 1> s1 = s4.first(1);
-		static_cast<void>(s1);
-	}
+    // ...or dynamically
+    {
+        // NB: implicit conversion to span<int,1> from span<int>
+//        span<int, 1> s1 = s4.first(1);
+//        static_cast<void>(s1);
+    }
 
-	// initialization or assignment to static span that requires size INCREASE is not ok.
-	int arr2[2] = {1, 2};
-	(void)arr2;
+    // initialization or assignment to static span that requires size INCREASE is not ok.
+    int arr2[2] = {1, 2};
+    (void) arr2;
 
-	static_assert(!std::is_constructible<span<int, 4>, decltype((arr2))>::value);
-	static_assert(!std::is_constructible<span<int, 4>, span<int, 2>>::value);
+    static_assert(
+        !std::is_constructible<span<int, 4>, decltype((arr2))>::value);
+    static_assert(!std::is_constructible<span<int, 4>, span<int, 2>>::value);
 }
 
 void test_case_interop_with_std_regex()
 {
-	char lat[] = {'1', '2', '3', '4', '5', '6', 'E', 'F', 'G'};
-	span<char> s = lat;
-	const auto f_it = s.begin() + 7;
+    char lat[] = {'1', '2', '3', '4', '5', '6', 'E', 'F', 'G'};
+    span<char> s = lat;
+    const auto f_it = s.begin() + 7;
 
-	std::match_results<span<char>::iterator> match;
+    std::match_results<span<char>::iterator> match;
 
-	std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
-	CHECK(match.ready());
-	CHECK(!match.empty());
-	CHECK(match[0].matched);
-	CHECK(match[0].first == s.begin());
-	CHECK(match[0].second == s.end());
+    std::regex_match(s.begin(), s.end(), match, std::regex(".*"));
+    CHECK(match.ready());
+    CHECK(!match.empty());
+    CHECK(match[0].matched);
+    CHECK(match[0].first == s.begin());
+    CHECK(match[0].second == s.end());
 
-	std::regex_search(s.begin(), s.end(), match, std::regex("F"));
-	CHECK(match.ready());
-	CHECK(!match.empty());
-	CHECK(match[0].matched);
-	CHECK(match[0].first == f_it);
-	CHECK(match[0].second == (f_it + 1));
+    std::regex_search(s.begin(), s.end(), match, std::regex("F"));
+    CHECK(match.ready());
+    CHECK(!match.empty());
+    CHECK(match[0].matched);
+    CHECK(match[0].first == f_it);
+    CHECK(match[0].second == (f_it + 1));
 }
 
-void test_case_default_constructible()
+void test_case_default_initializable()
 {
-	CHECK((std::is_default_constructible<span<int>>::value));
-	CHECK((std::is_default_constructible<span<int, 0>>::value));
-	CHECK((std::is_default_constructible<span<int, 42>>::value));
+    CHECK((std::is_default_constructible<span<int>>::value));
+    CHECK((std::is_default_constructible<span<int, 0>>::value));
+//    CHECK((std::is_default_constructible<span<int, 42>>::value));
 }
 
-int main() {
+} // anonymous namespace
+
+TEST_CASE("views.span")
+{
 	test_case_default_constructor();
 	test_case_size_optimization();
 	test_case_from_nullptr_constructor();
@@ -1062,7 +999,7 @@ int main() {
 	test_case_from_array_constructor();
 	test_case_from_std_array_constructor();
 	test_case_from_const_std_array_constructor();
-	test_case_from_std_array_const_constructor();
+	//test_case_from_std_array_const_constructor();
 	test_case_from_container_constructor();
 	test_case_from_convertible_span_constructor();
 	test_case_copy_move_and_assignment();
@@ -1074,26 +1011,30 @@ int main() {
 	test_case_iterator_comparisons();
 	test_case_begin_end();
 	test_case_rbegin_rend();
-	test_case_comparison_operators();
 	test_case_as_bytes();
 	test_case_as_writeable_bytes();
 	test_case_fixed_size_conversions();
 	test_case_interop_with_std_regex();
-	test_case_default_constructible();
+	test_case_default_initializable();
 
-	static_assert(ranges::ContiguousRange<span<int>> && ranges::View<span<int>>);
-	static_assert(ranges::ContiguousRange<span<int, 42>> && ranges::View<span<int, 42>>);
+	static_assert(ranges::contiguous_range<span<int>> && ranges::view<span<int>>);
+	// Fixed-sized span is not default-constructible => !view
+//	static_assert(ranges::contiguous_range<span<int, 42>> && ranges::view<span<int, 42>>);
+        static_assert(ranges::contiguous_range<span<int, 42>>);
 
 	// spans are non-dangling
-	static_assert(ranges::Same<decltype(ranges::begin(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::end(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::begin(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
-	static_assert(ranges::Same<decltype(ranges::end(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::begin(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::end(std::declval<span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::begin(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
+	static_assert(ranges::same_as<decltype(ranges::end(std::declval<const span<int>>())), ranges::iterator_t<span<int>>>);
+	{
+		int some_ints[]{42};
+		CHECK(ranges::data(span{some_ints, 42}) == +some_ints);
+	}
 
 	{
 		int some_ints[] = {0,1,2,3,4};
 		auto result = ranges::find(span{some_ints}, 3);
-		static_assert(ranges::Same<int*, decltype(result)>);
-		CHECK(result == some_ints + 3);
+		CHECK(*result == 3);
 	}
 }


### PR DESCRIPTION
`std::span` is a really weird thing, behaving like a view of a contiguous range (except that it sometimes doesn't actually model the `view` concept), but built using C++17-era idioms rather than the shiny new ranges stuff, and living in a completely different section of the standard.

This implementation of span is based on my own from https://github.com/tcbrindle/span, but simplified by assuming C++17 support and removing all the custom bounds-checking macro stuff -- this implementation just use uses plain old assert(). I believe it to be conforming to the current (pre-Belfast) working draft.

The tests are taken (as usual) from CMCSTL2, which in turn took them from the Microsoft GSL span implementation. I have modified them to remove/comment out various things which fail -- correctly, I think? -- due to the numerous changes span has undergone during its many visits to L(E)WG.