### PR TITLE
Use borrowed_range instead of forwarding_range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ cmake-build*/
 # VS
 .vs/
 CMakeSettings.json
+out/
 
 # conan
 .conan/test_package/build

--- a/include/nanorange/algorithm/adjacent_find.hpp
+++ b/include/nanorange/algorithm/adjacent_find.hpp
@@ -58,7 +58,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_relation<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{}) const
     {
         return adjacent_find_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/copy.hpp
+++ b/include/nanorange/algorithm/copy.hpp
@@ -83,7 +83,7 @@ public:
     template <typename Rng, typename O>
     constexpr std::enable_if_t<input_range<Rng> && weakly_incrementable<O> &&
                                    indirectly_copyable<iterator_t<Rng>, O>,
-                               copy_result<safe_iterator_t<Rng>, O>>
+                               copy_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result) const
     {
         return copy_fn::impl(nano::begin(rng), nano::end(rng),
@@ -162,7 +162,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> && weakly_incrementable<O> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        copy_if_result<safe_iterator_t<Rng>, O>>
+        copy_if_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, Pred pred, Proj proj = Proj{}) const
     {
         return copy_if_fn::impl(nano::begin(rng), nano::end(rng),
@@ -212,7 +212,7 @@ public:
     constexpr std::enable_if_t<bidirectional_range<Rng> &&
                                    bidirectional_iterator<I> &&
                                    indirectly_copyable<iterator_t<Rng>, I>,
-                               copy_backward_result<safe_iterator_t<Rng>, I>>
+                               copy_backward_result<borrowed_iterator_t<Rng>, I>>
     operator()(Rng&& rng, I result) const
     {
         return copy_backward_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/equal_range.hpp
+++ b/include/nanorange/algorithm/equal_range.hpp
@@ -43,7 +43,7 @@ public:
               typename Proj = identity>
     std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
-    safe_subrange_t<Rng>>
+                     borrowed_subrange_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},
                          Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/fill.hpp
+++ b/include/nanorange/algorithm/fill.hpp
@@ -36,7 +36,8 @@ public:
     }
 
     template <typename T, typename Rng>
-    constexpr std::enable_if_t<output_range<Rng, const T&>, safe_iterator_t<Rng>>
+    constexpr std::enable_if_t<output_range<Rng, const T&>,
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, const T& value) const
     {
         return fill_fn::impl(nano::begin(rng), nano::end(rng), value);

--- a/include/nanorange/algorithm/find.hpp
+++ b/include/nanorange/algorithm/find.hpp
@@ -47,7 +47,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return find_if_fn::impl(nano::begin(rng), nano::end(rng), pred, proj);
@@ -76,7 +76,7 @@ struct find_fn {
         input_range<Rng> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, const T& value, Proj proj = Proj{}) const
     {
         const auto pred = [&value] (const auto& t) { return t == value; };
@@ -119,7 +119,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         const auto find_if_pred = not_pred<Pred>{pred};

--- a/include/nanorange/algorithm/find_end.hpp
+++ b/include/nanorange/algorithm/find_end.hpp
@@ -68,7 +68,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng1> && forward_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>,
-            safe_subrange_t<Rng1>>
+        borrowed_subrange_t<Rng1>>
     operator()(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/find_first_of.hpp
+++ b/include/nanorange/algorithm/find_first_of.hpp
@@ -57,7 +57,7 @@ public:
         input_range<Rng1> && forward_range<Rng2> &&
             indirect_relation<Pred, projected<iterator_t<Rng1>, Proj1>,
                              projected<iterator_t<Rng2>, Proj2>>,
-        safe_iterator_t<Rng1>>
+        borrowed_iterator_t<Rng1>>
     operator()(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/for_each.hpp
+++ b/include/nanorange/algorithm/for_each.hpp
@@ -66,7 +66,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_invocable<Fun, projected<iterator_t<Rng>, Proj>>,
-        for_each_result<safe_iterator_t<Rng>, Fun>>
+        for_each_result<borrowed_iterator_t<Rng>, Fun>>
     operator()(Rng&& rng, Fun fun, Proj proj = Proj{}) const
     {
         return for_each_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/generate.hpp
+++ b/include/nanorange/algorithm/generate.hpp
@@ -41,7 +41,7 @@ public:
     template <typename Rng, typename F>
     constexpr std::enable_if_t<invocable<F&> &&
                                    output_range<Rng, invoke_result_t<F&>>,
-                               safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, F gen) const
     {
         return generate_fn::impl(nano::begin(rng), nano::end(rng), gen);

--- a/include/nanorange/algorithm/inplace_merge.hpp
+++ b/include/nanorange/algorithm/inplace_merge.hpp
@@ -199,7 +199,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     std::enable_if_t<bidirectional_range<Rng> &&
                          sortable<iterator_t<Rng>, Comp, Proj>,
-        safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, iterator_t<Rng> middle, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return inplace_merge_fn::impl(nano::begin(rng), std::move(middle),

--- a/include/nanorange/algorithm/is_heap_until.hpp
+++ b/include/nanorange/algorithm/is_heap_until.hpp
@@ -72,7 +72,7 @@ public:
     constexpr std::enable_if_t<
         random_access_range<Rng> &&
         indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return is_heap_until_fn::impl(nano::begin(rng), nano::distance(rng),

--- a/include/nanorange/algorithm/is_sorted_until.hpp
+++ b/include/nanorange/algorithm/is_sorted_until.hpp
@@ -54,7 +54,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return is_sorted_until_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/lower_bound.hpp
+++ b/include/nanorange/algorithm/lower_bound.hpp
@@ -57,7 +57,7 @@ public:
               typename Proj = identity>
     std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},
                          Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/make_heap.hpp
+++ b/include/nanorange/algorithm/make_heap.hpp
@@ -49,7 +49,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
                                    sortable<iterator_t<Rng>, Comp>,
-                               safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return make_heap_fn::impl(nano::begin(rng), nano::distance(rng), comp,

--- a/include/nanorange/algorithm/max_element.hpp
+++ b/include/nanorange/algorithm/max_element.hpp
@@ -49,7 +49,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-    safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return max_element_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/merge.hpp
+++ b/include/nanorange/algorithm/merge.hpp
@@ -84,7 +84,7 @@ public:
         input_range<Rng1> && input_range<Rng2> &&
         weakly_incrementable<O> &&
             mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, Comp, Proj1, Proj2>,
-        merge_result<safe_iterator_t<Rng1>, safe_iterator_t<Rng2>, O>>
+        merge_result<borrowed_iterator_t<Rng1>, borrowed_iterator_t<Rng2>, O>>
     operator()(Rng1&& rng1, Rng2&& rng2, O result, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/min_element.hpp
+++ b/include/nanorange/algorithm/min_element.hpp
@@ -52,7 +52,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return min_element_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/minmax_element.hpp
+++ b/include/nanorange/algorithm/minmax_element.hpp
@@ -95,7 +95,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        minmax_result<safe_iterator_t<Rng>>>
+        minmax_result<borrowed_iterator_t<Rng>>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return minmax_element_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/mismatch.hpp
+++ b/include/nanorange/algorithm/mismatch.hpp
@@ -98,7 +98,7 @@ public:
                 !input_range<I2> &&
             indirect_relation<Pred, projected<iterator_t<Rng1>, Proj1>,
                              projected<std::decay_t<I2>, Proj2>>,
-        mismatch_result<safe_iterator_t<Rng1>, std::decay_t<I2>>>
+        mismatch_result<borrowed_iterator_t<Rng1>, std::decay_t<I2>>>
     operator()(Rng1&& rng1, I2&& first2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {
@@ -131,7 +131,7 @@ public:
         input_range<Rng1> && input_range<Rng2> &&
             indirect_relation<Pred, projected<iterator_t<Rng1>, Proj1>,
                              projected<iterator_t<Rng2>, Proj2>>,
-        mismatch_result<safe_iterator_t<Rng1>, safe_iterator_t<Rng2>>>
+        mismatch_result<borrowed_iterator_t<Rng1>, borrowed_iterator_t<Rng2>>>
     operator()(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/move.hpp
+++ b/include/nanorange/algorithm/move.hpp
@@ -61,7 +61,7 @@ public:
     template <typename Rng, typename O>
     constexpr std::enable_if_t<input_range<Rng> && weakly_incrementable<O> &&
                                    indirectly_movable<iterator_t<Rng>, O>,
-                               move_result<safe_iterator_t<Rng>, O>>
+                               move_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result) const
     {
         return move_fn::impl(nano::begin(rng), nano::end(rng),
@@ -116,7 +116,7 @@ public:
     constexpr std::enable_if_t<bidirectional_range<Rng> &&
                                    bidirectional_iterator<O> &&
                                    indirectly_movable<iterator_t<Rng>, O>,
-                               move_backward_result<safe_iterator_t<Rng>, O>>
+                               move_backward_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result) const
     {
         return move_backward_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/next_permutation.hpp
+++ b/include/nanorange/algorithm/next_permutation.hpp
@@ -85,7 +85,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<
         bidirectional_range<Rng> && sortable<iterator_t<Rng>, Comp, Proj>,
-        next_permutation_result<safe_iterator_t<Rng>>>
+        next_permutation_result<borrowed_iterator_t<Rng>>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return next_permutation_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/nth_element.hpp
+++ b/include/nanorange/algorithm/nth_element.hpp
@@ -266,7 +266,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     std::enable_if_t<random_access_range<Rng> &&
                          sortable<iterator_t<Rng>, Comp, Proj>,
-    safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, iterator_t<Rng> nth,
                          Comp comp = Comp{}, Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/partial_sort.hpp
+++ b/include/nanorange/algorithm/partial_sort.hpp
@@ -51,7 +51,8 @@ public:
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
-                                   sortable<iterator_t<Rng>, Comp, Proj>, safe_iterator_t<Rng>>
+                                   sortable<iterator_t<Rng>, Comp, Proj>,
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, iterator_t<Rng> middle, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return partial_sort_fn::impl(nano::begin(rng), std::move(middle),

--- a/include/nanorange/algorithm/partial_sort_copy.hpp
+++ b/include/nanorange/algorithm/partial_sort_copy.hpp
@@ -74,7 +74,7 @@ public:
             indirectly_copyable<iterator_t<Rng1>, iterator_t<Rng2>> &&
             sortable<iterator_t<Rng2>, Comp, Proj2> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng1>, Proj1>, projected<iterator_t<Rng2>, Proj2>>,
-    safe_iterator_t<Rng2>>
+        borrowed_iterator_t<Rng2>>
     operator()(Rng1&& rng, Rng2&& result_rng, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/partition.hpp
+++ b/include/nanorange/algorithm/partition.hpp
@@ -52,7 +52,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return partition_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/partition_copy.hpp
+++ b/include/nanorange/algorithm/partition_copy.hpp
@@ -87,7 +87,7 @@ public:
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>> &&
             indirectly_copyable<iterator_t<Rng>, O1> &&
             indirectly_copyable<iterator_t<Rng>, O2>,
-        partition_copy_result<safe_iterator_t<Rng>, O1, O2>>
+        partition_copy_result<borrowed_iterator_t<Rng>, O1, O2>>
     operator()(Rng&& rng, O1 out_true, O2 out_false, Pred pred,
             Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/partition_point.hpp
+++ b/include/nanorange/algorithm/partition_point.hpp
@@ -97,7 +97,7 @@ public:
     std::enable_if_t<
         forward_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return partition_point_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/pop_heap.hpp
+++ b/include/nanorange/algorithm/pop_heap.hpp
@@ -44,7 +44,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
                                    sortable<iterator_t<Rng>, Comp, Proj>,
-                               safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return pop_heap_fn::impl(nano::begin(rng), nano::distance(rng), comp,

--- a/include/nanorange/algorithm/prev_permutation.hpp
+++ b/include/nanorange/algorithm/prev_permutation.hpp
@@ -84,7 +84,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<
         bidirectional_range<Rng> && sortable<iterator_t<Rng>, Comp, Proj>,
-        prev_permutation_result<safe_iterator_t<Rng>>>
+        prev_permutation_result<borrowed_iterator_t<Rng>>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return prev_permutation_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/push_heap.hpp
+++ b/include/nanorange/algorithm/push_heap.hpp
@@ -29,7 +29,7 @@ struct push_heap_fn {
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
                                    sortable<iterator_t<Rng>, Comp, Proj>,
-                               safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         const auto n = nano::distance(rng);

--- a/include/nanorange/algorithm/remove.hpp
+++ b/include/nanorange/algorithm/remove.hpp
@@ -52,7 +52,7 @@ public:
         forward_range<Rng> && permutable<iterator_t<Rng>> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, const T& value, Proj proj = Proj{}) const
     {
         return remove_fn::impl(nano::begin(rng), nano::end(rng), value, proj);

--- a/include/nanorange/algorithm/remove_copy.hpp
+++ b/include/nanorange/algorithm/remove_copy.hpp
@@ -55,7 +55,7 @@ public:
             indirectly_copyable<iterator_t<Rng>, O> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,
-        remove_copy_result<safe_iterator_t<Rng>, O>>
+        remove_copy_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, const T& value, Proj proj = Proj{}) const
     {
         return remove_copy_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/remove_copy_if.hpp
+++ b/include/nanorange/algorithm/remove_copy_if.hpp
@@ -53,7 +53,7 @@ public:
         input_range<Rng> && weakly_incrementable<O> &&
             indirectly_copyable<iterator_t<Rng>, O> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        remove_copy_if_result<safe_iterator_t<Rng>, O>>
+        remove_copy_if_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, Pred pred, Proj proj = Proj{}) const
     {
         return remove_copy_if_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/remove_if.hpp
+++ b/include/nanorange/algorithm/remove_if.hpp
@@ -51,7 +51,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> && permutable<iterator_t<Rng>> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return remove_if_fn::impl(nano::begin(rng), nano::end(rng), pred, proj);

--- a/include/nanorange/algorithm/replace.hpp
+++ b/include/nanorange/algorithm/replace.hpp
@@ -48,7 +48,7 @@ public:
         input_range<Rng> && writable<iterator_t<Rng>, const T2&> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T1*>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, const T1& old_value, const T2& new_value,
                Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/replace_copy.hpp
+++ b/include/nanorange/algorithm/replace_copy.hpp
@@ -60,7 +60,7 @@ public:
             indirectly_copyable<iterator_t<Rng>, O> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T1*>,
-        replace_copy_result<safe_iterator_t<Rng>, O>>
+        replace_copy_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, const T1& old_value, const T2& new_value,
                Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/replace_copy_if.hpp
+++ b/include/nanorange/algorithm/replace_copy_if.hpp
@@ -58,7 +58,7 @@ public:
         input_range<Rng> && output_iterator<O, const T&> &&
             indirectly_copyable<iterator_t<Rng>, O> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        replace_copy_if_result<safe_iterator_t<Rng>, O>>
+        replace_copy_if_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, Pred pred, const T& new_value,
                Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/replace_if.hpp
+++ b/include/nanorange/algorithm/replace_if.hpp
@@ -48,7 +48,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> && writable<iterator_t<Rng>, const T2&> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, const T2& new_value,
                Proj proj = Proj{}) const
     {

--- a/include/nanorange/algorithm/reverse.hpp
+++ b/include/nanorange/algorithm/reverse.hpp
@@ -47,7 +47,7 @@ public:
 
     template <typename Rng>
     constexpr std::enable_if_t<bidirectional_range<Rng>,
-        safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng) const
     {
         return reverse_fn::impl(nano::begin(rng), nano::end(rng));

--- a/include/nanorange/algorithm/reverse_copy.hpp
+++ b/include/nanorange/algorithm/reverse_copy.hpp
@@ -55,7 +55,7 @@ public:
     constexpr std::enable_if_t<bidirectional_range<Rng> &&
         weakly_incrementable<O> &&
                                    indirectly_copyable<iterator_t<Rng>, O>,
-        reverse_copy_result<safe_iterator_t<Rng>, O>>
+        reverse_copy_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result) const
     {
         return reverse_copy_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/rotate.hpp
+++ b/include/nanorange/algorithm/rotate.hpp
@@ -153,7 +153,7 @@ public:
     template <typename Rng>
     constexpr std::enable_if_t<
         forward_range<Rng> && permutable<iterator_t<Rng>>,
-        safe_subrange_t<Rng>>
+                               borrowed_subrange_t<Rng>>
     operator()(Rng&& rng, iterator_t<Rng> middle) const
     {
         return rotate_fn::impl(nano::begin(rng), std::move(middle), nano::end(rng));

--- a/include/nanorange/algorithm/rotate_copy.hpp
+++ b/include/nanorange/algorithm/rotate_copy.hpp
@@ -44,7 +44,7 @@ public:
     constexpr std::enable_if_t<forward_range<Rng> &&
         weakly_incrementable<O> &&
                                    indirectly_copyable<iterator_t<Rng>, O>,
-        rotate_copy_result<safe_iterator_t<Rng>, O>>
+        rotate_copy_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, iterator_t<Rng> middle, O result) const
     {
         return rotate_copy_fn::impl(nano::begin(rng), std::move(middle),

--- a/include/nanorange/algorithm/search.hpp
+++ b/include/nanorange/algorithm/search.hpp
@@ -68,7 +68,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng1> && forward_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>,
-            safe_subrange_t<Rng1>>
+        borrowed_subrange_t<Rng1>>
     operator()(Rng1&& rng1, Rng2&& rng2, Pred pred = Pred{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/search_n.hpp
+++ b/include/nanorange/algorithm/search_n.hpp
@@ -76,7 +76,7 @@ public:
     -> std::enable_if_t<
             forward_range<Rng> &&
                 indirectly_comparable<iterator_t<Rng>, const T*, Pred, Proj>,
-        safe_subrange_t<Rng>>
+            borrowed_subrange_t<Rng>>
     {
         return search_n_fn::impl(nano::begin(rng), nano::end(rng), count, value, pred,
                                  proj);

--- a/include/nanorange/algorithm/set_difference.hpp
+++ b/include/nanorange/algorithm/set_difference.hpp
@@ -86,7 +86,7 @@ public:
         input_range<Rng2> &&
         weakly_incrementable<O> &&
         mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, Comp, Proj1, Proj2>,
-        set_difference_result<safe_iterator_t<Rng1>, O>>
+        set_difference_result<borrowed_iterator_t<Rng1>, O>>
     operator()(Rng1&& rng1, Rng2&& rng2, O result, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/set_symmetric_difference.hpp
+++ b/include/nanorange/algorithm/set_symmetric_difference.hpp
@@ -90,8 +90,8 @@ public:
         input_range<Rng2> &&
         weakly_incrementable<O> &&
         mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, Comp, Proj1, Proj2>,
-        set_symmetric_difference_result<safe_iterator_t<Rng1>,
-                                        safe_iterator_t<Rng2>, O>>
+        set_symmetric_difference_result<borrowed_iterator_t<Rng1>,
+                                        borrowed_iterator_t<Rng2>, O>>
     operator()(Rng1&& rng1, Rng2&& rng2, O result, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/set_union.hpp
+++ b/include/nanorange/algorithm/set_union.hpp
@@ -94,7 +94,8 @@ public:
         input_range<Rng2> &&
         weakly_incrementable<O> &&
         mergeable<iterator_t<Rng1>, iterator_t<Rng2>, O, Comp, Proj1, Proj2>,
-        set_union_result<safe_iterator_t<Rng1>, safe_iterator_t<Rng2>, O>>
+        set_union_result<borrowed_iterator_t<Rng1>,
+                                                borrowed_iterator_t<Rng2>, O>>
     operator()(Rng1&& rng1, Rng2&& rng2, O result, Comp comp = Comp{},
                Proj1 proj1 = Proj1{}, Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/shuffle.hpp
+++ b/include/nanorange/algorithm/shuffle.hpp
@@ -53,7 +53,7 @@ public:
         random_access_range<Rng> &&
             uniform_random_bit_generator<std::remove_reference_t<Gen>> &&
             convertible_to<invoke_result_t<Gen&>, iter_difference_t<iterator_t<Rng>>>,
-    safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Gen&& gen) const
     {
         return shuffle_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/sort.hpp
+++ b/include/nanorange/algorithm/sort.hpp
@@ -27,7 +27,7 @@ struct sort_fn {
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
                                    sortable<iterator_t<Rng>, Comp, Proj>,
-    safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         iterator_t<Rng> last_it = nano::next(nano::begin(rng), nano::end(rng));

--- a/include/nanorange/algorithm/sort_heap.hpp
+++ b/include/nanorange/algorithm/sort_heap.hpp
@@ -44,7 +44,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     constexpr std::enable_if_t<random_access_range<Rng> &&
                                    sortable<iterator_t<Rng>, Comp, Proj>,
-                               safe_iterator_t<Rng>>
+                               borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return sort_heap_fn::impl(nano::begin(rng), nano::distance(rng), comp,

--- a/include/nanorange/algorithm/stable_partition.hpp
+++ b/include/nanorange/algorithm/stable_partition.hpp
@@ -160,7 +160,7 @@ public:
         bidirectional_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>> &&
             permutable<iterator_t<Rng>>,
-    safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return stable_partition_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/stable_sort.hpp
+++ b/include/nanorange/algorithm/stable_sort.hpp
@@ -170,7 +170,7 @@ public:
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
     std::enable_if_t<random_access_range<Rng> &&
                          sortable<iterator_t<Rng>, Comp, Proj>,
-    safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         auto first = nano::begin(rng);

--- a/include/nanorange/algorithm/swap_ranges.hpp
+++ b/include/nanorange/algorithm/swap_ranges.hpp
@@ -67,7 +67,8 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng1> && forward_range<Rng2> &&
             indirectly_swappable<iterator_t<Rng1>, iterator_t<Rng2>>,
-            swap_ranges_result<safe_iterator_t<Rng1>, safe_iterator_t<Rng2>>>
+            swap_ranges_result<borrowed_iterator_t<Rng1>,
+                           borrowed_iterator_t<Rng2>>>
     operator()(Rng1&& rng1, Rng2&& rng2) const
     {
         return swap_ranges_fn::impl4(nano::begin(rng1), nano::end(rng1),
@@ -79,7 +80,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng1> && forward_iterator<I2> &&
             indirectly_swappable<iterator_t<Rng1>, I2>,
-            swap_ranges_result<safe_iterator_t<Rng1>, I2>>
+            swap_ranges_result<borrowed_iterator_t<Rng1>, I2>>
     operator()(Rng1&& rng1, I2 first2) const
     {
         return swap_ranges_fn::impl3(nano::begin(rng1), nano::end(rng1),

--- a/include/nanorange/algorithm/transform.hpp
+++ b/include/nanorange/algorithm/transform.hpp
@@ -112,7 +112,7 @@ public:
         input_range<Rng> && weakly_incrementable<O> && copy_constructible<F> &&
             writable<O,
                      indirect_result_t<F&, projected<iterator_t<Rng>, Proj>>>,
-        unary_transform_result<safe_iterator_t<Rng>, O>>
+        unary_transform_result<borrowed_iterator_t<Rng>, O>>
     operator()(Rng&& rng, O result, F op, Proj proj = Proj{}) const
     {
         return transform_fn::unary_impl(nano::begin(rng), nano::end(rng),
@@ -146,7 +146,8 @@ public:
             writable<O,
                      indirect_result_t<F&, projected<iterator_t<Rng1>, Proj1>,
                                        projected<iterator_t<Rng2>, Proj2>>>,
-        binary_transform_result<safe_iterator_t<Rng1>, safe_iterator_t<Rng2>, O>>
+        binary_transform_result<borrowed_iterator_t<Rng1>,
+                                borrowed_iterator_t<Rng2>, O>>
     operator()(Rng1&& rng1, Rng2&& rng2, O result, F op, Proj1 proj1 = Proj1{},
                Proj2 proj2 = Proj2{}) const
     {
@@ -184,7 +185,7 @@ public:
             writable<O,
                      indirect_result_t<F&, projected<iterator_t<Rng1>, Proj1>,
                                        projected<std::decay_t<I2>, Proj2>>>,
-        binary_transform_result<safe_iterator_t<Rng1>, std::decay_t<I2>, O>>
+        binary_transform_result<borrowed_iterator_t<Rng1>, std::decay_t<I2>, O>>
     operator()(Rng1&& rng1, I2&& first2, O result, F op, Proj1 proj1 = Proj1{},
                Proj2 proj2 = Proj2{}) const
     {

--- a/include/nanorange/algorithm/unique.hpp
+++ b/include/nanorange/algorithm/unique.hpp
@@ -53,7 +53,7 @@ public:
         forward_range<Rng> &&
             indirect_relation<R, projected<iterator_t<Rng>, Proj>> &&
             permutable<iterator_t<Rng>>,
-            safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, R comp = {}, Proj proj = Proj{}) const
     {
         return unique_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/unique_copy.hpp
+++ b/include/nanorange/algorithm/unique_copy.hpp
@@ -78,7 +78,7 @@ public:
                 indirect_relation<Comp, projected<iterator_t<Rng>, Proj>> &&
                 indirectly_copyable<iterator_t<Rng>, O> &&
             decltype(constraint_helper<iterator_t<Rng>, O>(priority_tag<2>{}))::value,
-       unique_copy_result<safe_iterator_t<Rng>, O>>
+       unique_copy_result<borrowed_iterator_t<Rng>, O>>
     {
         return unique_copy_fn::impl(nano::begin(rng), nano::end(rng),
                                     std::move(result), comp, proj);

--- a/include/nanorange/algorithm/upper_bound.hpp
+++ b/include/nanorange/algorithm/upper_bound.hpp
@@ -56,7 +56,7 @@ public:
               typename Proj = identity>
     std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
-    safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},
                          Proj proj = Proj{}) const
     {

--- a/include/nanorange/detail/ranges/begin_end.hpp
+++ b/include/nanorange/detail/ranges/begin_end.hpp
@@ -9,8 +9,7 @@
 
 #include <nanorange/detail/functional/decay_copy.hpp>
 #include <nanorange/detail/iterator/concepts.hpp>
-
-#include <string_view>
+#include <nanorange/detail/ranges/borrowed_range.hpp>
 
 NANO_BEGIN_NAMESPACE
 
@@ -20,39 +19,35 @@ namespace detail {
 namespace begin_ {
 
 template <typename T>
-void begin(T&&) = delete;
+void begin(T&) = delete;
 
 template <typename T>
-void begin(std::initializer_list<T>&&) = delete;
+void begin(const T&) = delete;
 
 struct fn {
 private:
-    template <typename T, std::size_t N>
-    static constexpr void impl(T(&&)[N], priority_tag<2>) = delete;
+    template <typename T,
+              std::enable_if_t<
+                  !std::is_lvalue_reference_v<T> &&
+                  !enable_borrowed_range<std::remove_cv_t<T>>, int> = 0>
+    static constexpr void impl(T&&, priority_tag<3>) = delete;
 
-    template <typename T, std::size_t N>
-    static constexpr auto impl(T (&t)[N], priority_tag<2>) noexcept
-        -> decltype((t) + 0)
+    template <typename T,
+              std::enable_if_t<std::is_array_v<remove_cvref_t<T>>, int> = 0>
+    static constexpr auto impl(T&& t, priority_tag<2>) noexcept
+        -> decltype(t + 0)
     {
-        return (t) + 0;
-    }
-
-    // Specialisation for rvalue string_views in C++17, as we can't add
-    // functions to namespace std
-    template <typename C, typename T>
-    static constexpr auto
-    impl(std::basic_string_view<C, T> sv, priority_tag<2>) noexcept
-        -> decltype(sv.begin())
-    {
-        return sv.begin();
+        return t + 0;
     }
 
     template <typename T>
     static constexpr auto
-    impl(T& t, priority_tag<1>) noexcept(noexcept(decay_copy(t.begin())))
+    impl(T&& t, priority_tag<1>)
+        noexcept(noexcept(decay_copy(std::forward<T>(t).begin())))
         -> std::enable_if_t<
-            input_or_output_iterator<decltype(decay_copy(t.begin()))>,
-                            decltype(decay_copy(t.begin()))>
+            input_or_output_iterator<
+                decltype(decay_copy(std::forward<T>(t).begin()))>,
+                decltype(decay_copy(std::forward<T>(t).begin()))>
     {
         return decay_copy(t.begin());
     }
@@ -69,10 +64,10 @@ private:
 public:
     template <typename T>
     constexpr auto operator()(T&& t) const
-        noexcept(noexcept(fn::impl(std::forward<T>(t), priority_tag<2>{})))
-            -> decltype(fn::impl(std::forward<T>(t), priority_tag<2>{}))
+        noexcept(noexcept(fn::impl(std::forward<T>(t), priority_tag<3>{})))
+            -> decltype(fn::impl(std::forward<T>(t), priority_tag<3>{}))
     {
-        return fn::impl(std::forward<T>(t), priority_tag<2>{});
+        return fn::impl(std::forward<T>(t), priority_tag<3>{});
     }
 };
 
@@ -85,39 +80,37 @@ namespace detail {
 namespace end_ {
 
 template <typename T>
-void end(T&&) = delete;
+void end(T&) = delete;
 
 template <typename T>
-void end(std::initializer_list<T>&&) = delete;
+void end(const T&) = delete;
 
 struct fn {
 private:
-    template <typename T, std::size_t N>
-    static constexpr void impl(T(&&)[N], priority_tag<2>) = delete;
+    template <typename T,
+              std::enable_if_t<
+                  !std::is_lvalue_reference_v<T> &&
+                  !enable_borrowed_range<std::remove_cv_t<T>>, int> = 0>
+    static constexpr void impl(T&&, priority_tag<3>) = delete;
 
-    template <typename T, std::size_t N>
-    static constexpr auto impl(T (&t)[N], priority_tag<2>) noexcept
-        -> decltype(t + N)
+    template <typename T,
+              std::enable_if_t<std::is_array_v<remove_cvref_t<T>>, int> = 0>
+    static constexpr auto impl(T&& t, priority_tag<2>) noexcept
+        -> decltype(t + std::extent_v<remove_cvref_t<T>>)
     {
-        return t + N;
-    }
-
-    template <typename C, typename T>
-    static constexpr auto
-    impl(std::basic_string_view<C, T> sv, priority_tag<2>) noexcept
-        -> decltype(sv.end())
-    {
-        return sv.end();
+        return t + std::extent_v<remove_cvref_t<T>>;
     }
 
     template <typename T,
-              typename S = decltype(decay_copy(std::declval<T&>().end())),
-              typename I = decltype(ranges::begin(std::declval<T&>()))>
+              typename S = decltype(decay_copy(std::declval<T>().end())),
+              typename I = decltype(ranges::begin(std::declval<T>()))>
     static constexpr auto
-    impl(T& t, priority_tag<1>) noexcept(noexcept(decay_copy(t.end())))
-        -> std::enable_if_t<sentinel_for<S, I>, decltype(decay_copy(t.end()))>
+    impl(T&& t, priority_tag<1>)
+        noexcept(noexcept(decay_copy(std::forward<T>(t).end())))
+        -> std::enable_if_t<sentinel_for<S, I>,
+                            decltype(decay_copy(std::forward<T>(t).end()))>
     {
-        return decay_copy(t.end());
+        return decay_copy(std::forward<T>(t).end());
     }
 
     template <typename T,
@@ -133,10 +126,10 @@ private:
 public:
     template <typename T>
     constexpr auto operator()(T&& t) const
-        noexcept(noexcept(fn::impl(std::forward<T>(t), priority_tag<2>{})))
-            -> decltype(fn::impl(std::forward<T>(t), priority_tag<2>{}))
+        noexcept(noexcept(fn::impl(std::forward<T>(t), priority_tag<3>{})))
+            -> decltype(fn::impl(std::forward<T>(t), priority_tag<3>{}))
     {
-        return fn::impl(std::forward<T>(t), priority_tag<2>{});
+        return fn::impl(std::forward<T>(t), priority_tag<3>{});
     }
 };
 
@@ -151,20 +144,32 @@ namespace detail {
 namespace cbegin_ {
 
 struct fn {
-
-    template <typename T>
-    constexpr auto operator()(const T& t) const
-        noexcept(noexcept(ranges::begin(t))) -> decltype(ranges::begin(t))
+private:
+    template <typename T, typename U = std::remove_reference_t<T>,
+              std::enable_if_t<std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::begin(static_cast<const U&>(std::forward<T>(t)))))
+        -> decltype(ranges::begin(static_cast<const U&>(std::forward<T>(t))))
     {
-        return ranges::begin(t);
+        return ranges::begin(static_cast<const U&>(std::forward<T>(t)));
     }
 
-    template <typename T>
-    constexpr auto operator()(const T&& t) const
-        noexcept(noexcept(ranges::begin(static_cast<const T&&>(t))))
-            -> decltype(ranges::begin(static_cast<const T&&>(t)))
+    template <typename T,
+              std::enable_if_t<!std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::begin(static_cast<const T&&>(std::forward<T>(t)))))
+        -> decltype(ranges::begin(static_cast<const T&&>(std::forward<T>(t))))
     {
-        return ranges::begin(static_cast<const T&&>(t));
+        return ranges::begin(static_cast<const T&&>(std::forward<T>(t)));
+    }
+
+public:
+    template <typename T>
+    constexpr auto operator()(T&& t) const
+        noexcept(noexcept(fn::impl(std::forward<T>(t))))
+        -> decltype(fn::impl(std::forward<T>(t)))
+    {
+        return fn::impl(std::forward<T>(t));
     }
 };
 
@@ -179,21 +184,34 @@ namespace detail {
 namespace cend_ {
 
 struct fn {
-
-    template <typename T>
-    constexpr auto operator()(const T& t) const
-        noexcept(noexcept(ranges::end(t))) -> decltype(ranges::end(t))
+private:
+    template <typename T, typename U = std::remove_reference_t<T>,
+              std::enable_if_t<std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::end(static_cast<const U&>(std::forward<T>(t)))))
+        -> decltype(ranges::end(static_cast<const U&>(std::forward<T>(t))))
     {
-        return ranges::end(t);
+        return ranges::end(static_cast<const U&>(std::forward<T>(t)));
     }
 
-    template <typename T>
-    constexpr auto operator()(const T&& t) const
-        noexcept(noexcept(ranges::end(static_cast<const T&&>(t))))
-            -> decltype(ranges::end(static_cast<const T&&>(t)))
+    template <typename T,
+              std::enable_if_t<!std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::end(static_cast<const T&&>(std::forward<T>(t)))))
+        -> decltype(ranges::end(static_cast<const T&&>(std::forward<T>(t))))
     {
-        return ranges::end(static_cast<const T&&>(t));
+        return ranges::end(static_cast<const T&&>(std::forward<T>(t)));
     }
+
+public:
+    template <typename T>
+    constexpr auto operator()(T&& t) const
+        noexcept(noexcept(fn::impl(std::forward<T>(t))))
+        -> decltype(fn::impl(std::forward<T>(t)))
+    {
+        return fn::impl(std::forward<T>(t));
+    }
+
 };
 
 } // namespace cend_

--- a/include/nanorange/detail/ranges/begin_end.hpp
+++ b/include/nanorange/detail/ranges/begin_end.hpp
@@ -148,10 +148,10 @@ private:
     template <typename T, typename U = std::remove_reference_t<T>,
               std::enable_if_t<std::is_lvalue_reference_v<T>, int> = 0>
     static constexpr auto impl(T&& t)
-        noexcept(noexcept(ranges::begin(static_cast<const U&>(std::forward<T>(t)))))
-        -> decltype(ranges::begin(static_cast<const U&>(std::forward<T>(t))))
+        noexcept(noexcept(ranges::begin(static_cast<const U&>(t))))
+        -> decltype(ranges::begin(static_cast<const U&>(t)))
     {
-        return ranges::begin(static_cast<const U&>(std::forward<T>(t)));
+        return ranges::begin(static_cast<const U&>(t));
     }
 
     template <typename T,
@@ -188,10 +188,10 @@ private:
     template <typename T, typename U = std::remove_reference_t<T>,
               std::enable_if_t<std::is_lvalue_reference_v<T>, int> = 0>
     static constexpr auto impl(T&& t)
-        noexcept(noexcept(ranges::end(static_cast<const U&>(std::forward<T>(t)))))
-        -> decltype(ranges::end(static_cast<const U&>(std::forward<T>(t))))
+        noexcept(noexcept(ranges::end(static_cast<const U&>(t))))
+        -> decltype(ranges::end(static_cast<const U&>(t)))
     {
-        return ranges::end(static_cast<const U&>(std::forward<T>(t)));
+        return ranges::end(static_cast<const U&>(t));
     }
 
     template <typename T,

--- a/include/nanorange/detail/ranges/borrowed_range.hpp
+++ b/include/nanorange/detail/ranges/borrowed_range.hpp
@@ -1,0 +1,19 @@
+// nanorange/detail/ranges/borrowed_range.hpp
+//
+// Copyright (c) 2020 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_DETAIL_RANGES_BORROWED_RANGE_HPP_INCLUDED
+#define NANORANGE_DETAIL_RANGES_BORROWED_RANGE_HPP_INCLUDED
+
+#include <nanorange/detail/macros.hpp>
+
+NANO_BEGIN_NAMESPACE
+
+template <typename>
+inline constexpr bool enable_borrowed_range = false;
+
+NANO_END_NAMESPACE
+
+#endif

--- a/include/nanorange/detail/ranges/concepts.hpp
+++ b/include/nanorange/detail/ranges/concepts.hpp
@@ -59,9 +59,8 @@ template <typename CharT, typename Traits>
 inline constexpr bool
     enable_borrowed_range<std::basic_string_view<CharT, Traits>> = true;
 
-template <typename R>
-using iterator_t = std::enable_if_t<range<R>,
-    decltype(ranges::begin(std::declval<R&>()))>;
+template <typename T>
+using iterator_t = decltype(ranges::begin(std::declval<T&>()));
 
 template <typename R>
 using sentinel_t = std::enable_if_t<range<R>,

--- a/include/nanorange/memory/destroy.hpp
+++ b/include/nanorange/memory/destroy.hpp
@@ -44,7 +44,7 @@ public:
     template <typename Rng>
     std::enable_if_t<no_throw_input_range<Rng> &&
         destructible<iter_value_t<iterator_t<Rng>>>,
-        safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     operator()(Rng&& rng) const noexcept
     {
         return destroy_fn::impl(nano::begin(rng), nano::end(rng));

--- a/include/nanorange/memory/uninitialized_copy.hpp
+++ b/include/nanorange/memory/uninitialized_copy.hpp
@@ -77,7 +77,8 @@ public:
     std::enable_if_t<
         input_range<IRng> && no_throw_forward_range<ORng> &&
         constructible_from<iter_value_t<iterator_t<ORng>>, iter_reference_t<iterator_t<IRng>>>,
-        uninitialized_copy_result<safe_iterator_t<IRng>, safe_iterator_t<ORng>>>
+        uninitialized_copy_result<borrowed_iterator_t<IRng>,
+                                               borrowed_iterator_t<ORng>>>
     operator()(IRng&& irng, ORng&& orng) const
     {
         return uninitialized_copy_fn::impl4(
@@ -106,7 +107,7 @@ public:
         input_range<IRng> && no_throw_forward_iterator<std::decay_t<O>> &&
         !no_throw_forward_range<O> &&
         constructible_from<iter_value_t<std::decay_t<O>>, iter_reference_t<iterator_t<IRng>>>,
-        uninitialized_copy_result<safe_iterator_t<IRng>, std::decay_t<O>>>
+        uninitialized_copy_result<borrowed_iterator_t<IRng>, std::decay_t<O>>>
     operator()(IRng&& irng, O&& ofirst) const
     {
         return uninitialized_copy_fn::impl3(

--- a/include/nanorange/memory/uninitialized_default_construct.hpp
+++ b/include/nanorange/memory/uninitialized_default_construct.hpp
@@ -43,7 +43,7 @@ public:
     template <typename Rng>
     std::enable_if_t<no_throw_forward_range<Rng> &&
         default_constructible<iter_value_t<iterator_t<Rng>>>,
-        safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     operator()(Rng&& rng) const
     {
         return uninitialized_default_construct_fn::impl(

--- a/include/nanorange/memory/uninitialized_fill.hpp
+++ b/include/nanorange/memory/uninitialized_fill.hpp
@@ -47,7 +47,7 @@ public:
     std::enable_if_t<
         no_throw_forward_range<Rng> &&
         constructible_from<iter_value_t<iterator_t<Rng>>, const T&>,
-        safe_iterator_t<Rng>>
+        borrowed_iterator_t<Rng>>
     operator()(Rng&& rng, const T& x) const
     {
         return uninitialized_fill_fn::impl(nano::begin(rng), nano::end(rng), x);

--- a/include/nanorange/memory/uninitialized_move.hpp
+++ b/include/nanorange/memory/uninitialized_move.hpp
@@ -75,7 +75,8 @@ public:
     std::enable_if_t<
         input_range<IRng> && no_throw_forward_range<ORng> &&
         constructible_from<iter_value_t<iterator_t<ORng>>, iter_rvalue_reference_t<iterator_t<IRng>>>,
-        uninitialized_move_result<safe_iterator_t<IRng>, safe_iterator_t<ORng>>>
+        uninitialized_move_result<borrowed_iterator_t<IRng>,
+                                  borrowed_iterator_t<ORng>>>
     operator()(IRng&& irng, ORng&& orng) const
     {
         return uninitialized_move_fn::impl4(
@@ -104,7 +105,7 @@ public:
         input_range<IRng> && no_throw_forward_iterator<std::decay_t<O>> &&
         !no_throw_forward_range<O> &&
         constructible_from<iter_value_t<std::decay_t<O>>, iter_rvalue_reference_t<iterator_t<IRng>>>,
-        uninitialized_move_result<safe_iterator_t<IRng>, std::decay_t<O>>>
+        uninitialized_move_result<borrowed_iterator_t<IRng>, std::decay_t<O>>>
     operator()(IRng&& irng, O&& ofirst) const
     {
         return uninitialized_move_fn::impl3(

--- a/include/nanorange/memory/uninitialized_value_construct.hpp
+++ b/include/nanorange/memory/uninitialized_value_construct.hpp
@@ -43,7 +43,7 @@ public:
     template <typename Rng>
     std::enable_if_t<no_throw_forward_range<Rng> &&
         default_constructible<iter_value_t<iterator_t<Rng>>>,
-        safe_iterator_t<Rng>>
+                     borrowed_iterator_t<Rng>>
     operator()(Rng&& rng) const
     {
         return uninitialized_value_construct_fn::impl(

--- a/include/nanorange/views/empty.hpp
+++ b/include/nanorange/views/empty.hpp
@@ -33,6 +33,9 @@ public:
 
 using empty_view_::empty_view;
 
+template <typename T>
+inline constexpr bool enable_borrowed_range<empty_view<T>> = true;
+
 namespace views {
 
 template <typename T, typename = std::enable_if_t<std::is_object<T>::value>>

--- a/include/nanorange/views/iota.hpp
+++ b/include/nanorange/views/iota.hpp
@@ -351,6 +351,9 @@ template <typename W, typename Bound, std::enable_if_t<
         (signed_integral<W> == signed_integral<Bound>), int> = 0>
 iota_view(W, Bound) -> iota_view<W, Bound>;
 
+template <typename W, typename Bound>
+inline constexpr bool enable_borrowed_range<iota_view<W, Bound>> = true;
+
 namespace views {
 
 namespace detail {

--- a/include/nanorange/views/ref.hpp
+++ b/include/nanorange/views/ref.hpp
@@ -63,10 +63,6 @@ public:
     {
         return ranges::data(*r_);
     }
-
-    friend constexpr iterator_t<R> begin(ref_view r) { return r.begin(); }
-
-    friend constexpr sentinel_t<R> end(ref_view r) { return r.end(); }
 };
 
 template <typename R, std::enable_if_t<range<R> && std::is_object_v<R>, int> = 0>
@@ -75,6 +71,9 @@ ref_view(R&) -> ref_view<R>;
 } // namespace ref_view_
 
 using ref_view_::ref_view;
+
+template <typename R>
+inline constexpr bool enable_borrowed_range<ref_view<R>> = true;
 
 NANO_END_NAMESPACE
 

--- a/test/algorithm/fill_n.cpp
+++ b/test/algorithm/fill_n.cpp
@@ -40,7 +40,7 @@ I count_and_fill(I i, S s, const T &t) {
 
 template<class Rng, class T>
 //	requires stl2::Writable<stl2::iterator_t<Rng>, const T&>
-stl2::safe_iterator_t<Rng> count_and_fill(Rng &&rng, const T &t) {
+stl2::borrowed_iterator_t<Rng> count_and_fill(Rng &&rng, const T &t) {
 	return stl2::fill_n(stl2::begin(rng), stl2::distance(rng), t);
 }
 

--- a/test/iterator/ostreambuf_iterator.cpp
+++ b/test/iterator/ostreambuf_iterator.cpp
@@ -35,8 +35,8 @@ namespace {
 
 	template <typename R, typename O>
 	constexpr
-	//tagged_pair<tag::in(safe_iterator_t<R>), tag::out(O)>
-	std::pair<safe_iterator_t<R>, O>
+	//tagged_pair<tag::in(borrowed_iterator_t<R>), tag::out(O)>
+	std::pair<borrowed_iterator_t<R>, O>
 	copy(R&& range, O out) {
 		return ::copy(std::begin(range), std::end(range), std::move(out));
 	}

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -139,11 +139,15 @@ void test()
                                   const int*>);
 
     // Ill-formed: array rvalue
+    // MSVC bug handing rvalue-reference-to-array types
+    // https://developercommunity.visualstudio.com/content/problem/203305/rvalue-reference-to-array-can-bind-to-lvalue-refer.html
+#if !(defined(_MSC_VER) && _MSC_VER < 1923)
     static_assert(!CanBegin<int(&&)[2]>);
     static_assert(!CanBegin<const int(&&)[2]>);
 
     static_assert(!CanCBegin<int(&&)[2]>);
     static_assert(!CanCBegin<const int(&&)[2]>);
+#endif
 
     // Valid: only member begin
     static_assert(CanBegin<A&>);

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -10,193 +10,311 @@
 //
 // Project home: https://github.com/caseycarter/cmcstl2
 //
-#include <nanorange/ranges.hpp>
+
+#include <nanorange/algorithm/find.hpp>
+#include <nanorange/views/subrange.hpp>
+#include <nanorange/views/ref.hpp>
+#include <nanorange/views/iota.hpp>
 #include <iostream>
 #include <vector>
 #include <utility>
-#include <nanorange/views/subrange.hpp>
-
-#include <string_view>
-#include <nanorange/algorithm/find.hpp>
-
 #include "catch.hpp"
+
+namespace ranges = nano::ranges;
 
 namespace {
 
-namespace ranges = nano;
-
-void test_range_access_ambiguity() {
-	std::vector<ranges::reverse_iterator<int*>> vri{};
-	using namespace ranges;
-	(void)begin(vri);
-	(void)end(vri);
-	(void)cbegin(vri);
-	(void)cend(vri);
-	(void)rbegin(vri);
-	(void)rend(vri);
-	(void)crbegin(vri);
-	(void)crend(vri);
+void test_range_access_ambiguity()
+{
+    std::vector<ranges::reverse_iterator<int*>> vri{};
+    using namespace ranges;
+    (void) begin(vri);
+    (void) end(vri);
+    (void) cbegin(vri);
+    (void) cend(vri);
+    (void) rbegin(vri);
+    (void) rend(vri);
+    (void) crbegin(vri);
+    (void) crend(vri);
 }
 
-void test_initializer_list() {
-	std::initializer_list<int> il = {0,1,2};
-	{
-		int count = 0;
-		for (auto p = ranges::begin(il), e = ranges::end(il); p != e; ++p) {
-			CHECK(*p == count++);
-		}
-	}
-	{
-		int count = 3;
-		for (auto p = ranges::rbegin(il), e = ranges::rend(il); p != e; ++p) {
-			CHECK(*p == --count);
-		}
-	}
-	CHECK(ranges::size(il) == std::size_t{3});
-	CHECK(ranges::data(il) == &*il.begin());
-	CHECK(ranges::empty(il) == false);
+void test_initializer_list()
+{
+    std::initializer_list<int> il = {0, 1, 2};
+    {
+        int count = 0;
+        for (auto p = ranges::begin(il), e = ranges::end(il); p != e; ++p) {
+            CHECK(*p == count++);
+        }
+    }
+    {
+        int count = 3;
+        for (auto p = ranges::rbegin(il), e = ranges::rend(il); p != e; ++p) {
+            CHECK(*p == --count);
+        }
+    }
+    CHECK(ranges::size(il) == std::size_t{3});
+    CHECK(ranges::data(il) == &*il.begin());
+    CHECK(ranges::empty(il) == false);
 }
 
 template <class T, std::size_t... Is>
-void test_array(std::index_sequence<Is...>) {
-	T a[sizeof...(Is)] = { Is... };
-	{
-		int count = 0;
-		for (auto p = ranges::begin(a), e = ranges::end(a); p != e; ++p) {
-			CHECK(*p == count++);
-		}
-	}
-	{
-		int count = sizeof...(Is);
-		for (auto p = ranges::rbegin(a), e = ranges::rend(a); p != e; ++p) {
-			CHECK(*p == --count);
-		}
-	}
-	CHECK(ranges::size(a) == sizeof...(Is));
-	CHECK(ranges::data(a) == a + 0);
-	CHECK(ranges::empty(a) == false);
+void test_array(std::index_sequence<Is...>)
+{
+    T a[sizeof...(Is)] = {Is...};
+    {
+        int count = 0;
+        for (auto p = ranges::begin(a), e = ranges::end(a); p != e; ++p) {
+            CHECK(*p == count++);
+        }
+    }
+    {
+        int count = sizeof...(Is);
+        for (auto p = ranges::rbegin(a), e = ranges::rend(a); p != e; ++p) {
+            CHECK(*p == --count);
+        }
+    }
+    CHECK(ranges::size(a) == sizeof...(Is));
+    CHECK(ranges::data(a) == a + 0);
+    CHECK(ranges::empty(a) == false);
 }
 
 namespace begin_testing {
-	//template <class R>
-	//concept bool CanBegin =
-	//	requires(R&& r) {
-	//		ranges::begin((R&&)r);
-	//	};
-	struct CanBegin_r {
-		template <class R>
-		auto requires_(R&& r) -> decltype(ranges::begin((R&&)r));
-	};
 
-	template <class R>
-	constexpr bool can_begin = ranges::detail::requires_<CanBegin_r, R>;
+struct CanBegin_concept {
+    template <class R>
+    auto requires_(R&& r) -> decltype(
+        ranges::begin((R &&) r)
+    );
+};
 
-	struct A {
-		int* begin();
-		int* end();
-		const int* begin() const;
-		const int* end() const;
-	};
+template <class R>
+NANO_CONCEPT CanBegin = ranges::detail::requires_<CanBegin_concept, R>;
 
-	struct B : A {};
-	void* begin(B&) { return nullptr; }
+struct CanCBegin_concept {
+    template <class R>
+    auto requires_(R&& r) -> decltype(
+        ranges::cbegin((R &&) r)
+    );
+};
 
-	struct C : A {};
-	void begin(C&) {}
+template <class R>
+NANO_CONCEPT CanCBegin = ranges::detail::requires_<CanCBegin_concept, R>;
 
-	struct D : A {};
-	char* begin(D&) { return 0; }
+struct A {
+    int* begin();
+    int* end();
+    const int* begin() const;
+    const int* end() const;
+};
 
-	void test() {
-		namespace models = ranges;
+struct B : A {};
+void* begin(B&);
 
-		// Valid
-		static_assert(can_begin<int(&)[2]>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<int(&)[2]>())), int*>, "");
-		static_assert(can_begin<const int(&)[2]>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<const int(&)[2]>())), const int*>, "");
+struct C : A {};
+void begin(C&);
 
-		// Ill-formed: array rvalue
-		// FIXME: MSVC
-#ifndef _MSC_VER
-		static_assert(!can_begin<int(&&)[2]>, "");
-#endif
+struct D : A {};
+char* begin(D&);
 
-		// Valid: only member begin
-		static_assert(can_begin<A&>, "");
-		static_assert(!can_begin<A>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<A&>())), int*>, "");
-		static_assert(can_begin<const A&>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<const A&>())), const int*>, "");
+void test()
+{
+    // Valid
+    static_assert(CanBegin<int(&)[2]>);
+    static_assert(
+        ranges::same_as<decltype(ranges::begin(std::declval<int(&)[2]>())),
+                        int*>);
+    static_assert(CanBegin<const int(&)[2]>);
+    static_assert(ranges::same_as<decltype(ranges::begin(
+                                      std::declval<const int(&)[2]>())),
+                                  const int*>);
 
-		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
-		static_assert(can_begin<B&>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<B&>())), int*>, "");
-		static_assert(can_begin<const B&>, "");
-		static_assert(models::same_as<decltype(ranges::begin(std::declval<const B&>())), const int*>, "");
+    static_assert(CanCBegin<int(&)[2]>);
+    static_assert(
+        ranges::same_as<decltype(ranges::cbegin(std::declval<int(&)[2]>())),
+                        const int*>);
+    static_assert(CanCBegin<const int(&)[2]>);
+    static_assert(ranges::same_as<decltype(ranges::cbegin(
+                                      std::declval<const int(&)[2]>())),
+                                  const int*>);
 
-		// Valid: Both member and non-member begin, but non-member returns non-Iterator.
-		static_assert(can_begin<C&>, "");
-		static_assert(can_begin<const C&>, "");
+    // Ill-formed: array rvalue
+    static_assert(!CanBegin<int(&&)[2]>);
+    static_assert(!CanBegin<const int(&&)[2]>);
 
-		// Valid: Prefer member begin
-		static_assert(can_begin<D&>, "");
-		static_assert(models::same_as<int*, decltype(ranges::begin(std::declval<D&>()))>, "");
-		static_assert(can_begin<const D&>, "");
-		static_assert(models::same_as<const int*, decltype(ranges::begin(std::declval<const D&>()))>, "");
+    static_assert(!CanCBegin<int(&&)[2]>);
+    static_assert(!CanCBegin<const int(&&)[2]>);
 
-		{
-			using T = std::initializer_list<int>;
-			// Valid: begin accepts lvalue initializer_list
-			static_assert(models::same_as<const int*, decltype(ranges::begin(std::declval<T&>()))>, "");
-			static_assert(models::same_as<const int*, decltype(ranges::begin(std::declval<const T&>()))>, "");
-		}
+    // Valid: only member begin
+    static_assert(CanBegin<A&>);
+    static_assert(!CanBegin<A>);
+    static_assert(
+        ranges::same_as<decltype(ranges::begin(std::declval<A&>())), int*>);
+    static_assert(CanBegin<const A&>);
+    static_assert(!CanBegin<const A>);
+    static_assert(
+        ranges::same_as<decltype(ranges::begin(std::declval<const A&>())),
+                        const int*>);
 
-		static_assert(can_begin<ranges::subrange<int*, int*>&>, "");
-		static_assert(can_begin<ranges::subrange<int*, int*>&&>, "");
-	}
+    // Valid: Both member and non-member begin, but non-member returns non-input_or_output_iterator.
+    static_assert(CanBegin<B&>);
+    static_assert(!CanBegin<B>);
+    static_assert(
+        ranges::same_as<decltype(ranges::begin(std::declval<B&>())), int*>);
+    static_assert(CanBegin<const B&>);
+    static_assert(!CanBegin<const B>);
+    static_assert(
+        ranges::same_as<decltype(ranges::begin(std::declval<const B&>())),
+                        const int*>);
+
+    // Valid: Both member and non-member begin, but non-member returns non-input_or_output_iterator.
+    static_assert(CanBegin<C&>);
+    static_assert(!CanBegin<C>);
+    static_assert(CanBegin<const C&>);
+    static_assert(!CanBegin<const C>);
+
+    // Valid: Prefer member begin
+    static_assert(CanBegin<D&>);
+    static_assert(!CanBegin<D>);
+    static_assert(
+        ranges::same_as<int*, decltype(ranges::begin(std::declval<D&>()))>);
+    static_assert(CanBegin<const D&>);
+    static_assert(!CanBegin<const D>);
+    static_assert(ranges::same_as<const int*, decltype(ranges::begin(
+                                                  std::declval<const D&>()))>);
+
+    {
+        using T = std::initializer_list<int>;
+        // Valid: begin accepts lvalue initializer_list
+        static_assert(ranges::same_as<const int*, decltype(ranges::begin(
+                                                      std::declval<T&>()))>);
+        static_assert(
+            ranges::same_as<const int*,
+                            decltype(ranges::begin(std::declval<const T&>()))>);
+        static_assert(!CanBegin<std::initializer_list<int>>);
+        static_assert(!CanBegin<const std::initializer_list<int>>);
+    }
+
+    static_assert(CanBegin<ranges::subrange<int*, int*>&>);
+    static_assert(CanBegin<const ranges::subrange<int*, int*>&>);
+    static_assert(CanBegin<ranges::subrange<int*, int*>>);
+    static_assert(CanBegin<const ranges::subrange<int*, int*>>);
+
+    static_assert(CanCBegin<ranges::subrange<int*, int*>&>);
+    static_assert(CanCBegin<const ranges::subrange<int*, int*>&>);
+    static_assert(CanCBegin<ranges::subrange<int*, int*>>);
+    static_assert(CanCBegin<const ranges::subrange<int*, int*>>);
+
+    static_assert(CanBegin<ranges::ref_view<int[5]>&>);
+    static_assert(CanBegin<const ranges::ref_view<int[5]>&>);
+    static_assert(CanBegin<ranges::ref_view<int[5]>>);
+    static_assert(CanBegin<const ranges::ref_view<int[5]>>);
+
+    static_assert(CanCBegin<ranges::ref_view<int[5]>&>);
+    static_assert(CanCBegin<const ranges::ref_view<int[5]>&>);
+    static_assert(CanCBegin<ranges::ref_view<int[5]>>);
+    static_assert(CanCBegin<const ranges::ref_view<int[5]>>);
+
+    static_assert(CanBegin<ranges::iota_view<int, int>&>);
+    static_assert(CanBegin<const ranges::iota_view<int, int>&>);
+    static_assert(CanBegin<ranges::iota_view<int, int>>);
+    static_assert(CanBegin<const ranges::iota_view<int, int>>);
+
+    static_assert(CanCBegin<ranges::iota_view<int, int>&>);
+    static_assert(CanCBegin<const ranges::iota_view<int, int>&>);
+    static_assert(CanCBegin<ranges::iota_view<int, int>>);
+    static_assert(CanCBegin<const ranges::iota_view<int, int>>);
+}
 } // namespace begin_testing
 
 namespace X {
-	template <class T, std::size_t N>
-//		requires N != 0
-	struct array {
-		T elements_[N];
+template <class T, std::size_t N>
+/*requires(N != 0)*/ struct array {
+    T elements_[N];
 
-		constexpr bool empty() const noexcept { return N == 0; }
-		constexpr T* data() noexcept { return elements_; }
-		constexpr const T* data() const noexcept { return elements_; }
-	};
+    constexpr bool empty() const noexcept { return N == 0; }
+    constexpr T* data() noexcept { return elements_; }
+    constexpr const T* data() const noexcept { return elements_; }
+};
 
-	template <class T, std::size_t N>
-	constexpr T* begin(array<T, N>& a) noexcept { return a.elements_; }
-	template <class T, std::size_t N>
-	constexpr T* end(array<T, N>& a) noexcept { return a.elements_ + N; }
-	template <class T, std::size_t N>
-	constexpr const T* begin(const array<T, N>& a) noexcept { return a.elements_; }
-	template <class T, std::size_t N>
-	constexpr const T* end(const array<T, N>& a) noexcept { return a.elements_ + N; }
+template <class T, std::size_t N>
+constexpr T* begin(array<T, N>& a) noexcept
+{
+    return a.elements_;
+}
+template <class T, std::size_t N>
+constexpr T* end(array<T, N>& a) noexcept
+{
+    return a.elements_ + N;
+}
+template <class T, std::size_t N>
+constexpr const T* begin(const array<T, N>& a) noexcept
+{
+    return a.elements_;
+}
+template <class T, std::size_t N>
+constexpr const T* end(const array<T, N>& a) noexcept
+{
+    return a.elements_ + N;
+}
+
+template <class T, std::size_t N>
+/*requires(N != 0)*/ struct non_constexpr_array {
+    T elements_[N];
+
+    bool empty() const noexcept { return N == 0; }
+    T* data() noexcept { return elements_; }
+    const T* data() const noexcept { return elements_; }
+};
+
+template <class T, std::size_t N>
+T* begin(non_constexpr_array<T, N>& a) noexcept
+{
+    return a.elements_;
+}
+template <class T, std::size_t N>
+T* end(non_constexpr_array<T, N>& a) noexcept
+{
+    return a.elements_ + N;
+}
+template <class T, std::size_t N>
+const T* begin(const non_constexpr_array<T, N>& a) noexcept
+{
+    return a.elements_;
+}
+template <class T, std::size_t N>
+const T* end(const non_constexpr_array<T, N>& a) noexcept
+{
+    return a.elements_ + N;
+}
 } // namespace X
 
 using I = int*;
 using CI = const int*;
-static_assert(ranges::input_or_output_iterator<I>, "");
-static_assert(ranges::input_or_output_iterator<CI>, "");
+static_assert(ranges::input_or_output_iterator<I>);
+static_assert(ranges::input_or_output_iterator<CI>);
 
-void test_string_view_p0970() {
-	// basic_string_views are non-dangling
-	using I = ranges::iterator_t<std::string_view>;
-	static_assert(ranges::same_as<I, decltype(ranges::begin(std::declval<std::string_view>()))>);
-	static_assert(ranges::same_as<I, decltype(ranges::end(std::declval<std::string_view>()))>);
-	static_assert(ranges::same_as<I, decltype(ranges::begin(std::declval<const std::string_view>()))>);
-	static_assert(ranges::same_as<I, decltype(ranges::end(std::declval<const std::string_view>()))>);
+void test_string_view_p0970()
+{
+    // basic_string_views are non-dangling
+    using I = ranges::iterator_t<std::string_view>;
+    static_assert(ranges::same_as<I, decltype(ranges::begin(
+                                         std::declval<std::string_view>()))>);
+    static_assert(ranges::same_as<I, decltype(ranges::end(
+                                         std::declval<std::string_view>()))>);
+    static_assert(
+        ranges::same_as<I, decltype(ranges::begin(
+                               std::declval<const std::string_view>()))>);
+    static_assert(
+        ranges::same_as<I, decltype(ranges::end(
+                               std::declval<const std::string_view>()))>);
 
-	{
-		const char hw[] = "Hello, World!";
-		auto result = ranges::find(std::string_view{hw}, 'W');
-		static_assert(ranges::same_as<I, decltype(result)>);
-		CHECK(result == std::string_view{hw}.begin() + 7);
-	}
+    {
+        const char hw[] = "Hello, World!";
+        auto result = ranges::find(std::string_view{hw}, 'W');
+        static_assert(ranges::same_as<I, decltype(result)>);
+        CHECK(result == std::string_view{hw}.begin() + 7);
+    }
 }
 
 }
@@ -204,26 +322,27 @@ void test_string_view_p0970() {
 TEST_CASE("range_access") {
 	using namespace ranges;
 
-	test_range_access_ambiguity();
-
 	static constexpr X::array<int, 4> some_ints = {{0,1,2,3}};
 
 	constexpr auto first = begin(some_ints);
 	constexpr auto last = end(some_ints);
-	static_assert(same_as<const CI, decltype(first)>, "");
-	static_assert(same_as<const CI, decltype(last)>, "");
-	static_assert(first == cbegin(some_ints), "");
-	static_assert(last == cend(some_ints), "");
+	static_assert(ranges::same_as<const CI, decltype(first)>);
+	static_assert(ranges::same_as<const CI, decltype(last)>);
+	static_assert(first == cbegin(some_ints));
+	static_assert(last == cend(some_ints));
 
-	static_assert(noexcept(begin(some_ints)), "");
-	static_assert(noexcept(end(some_ints)), "");
-	static_assert(noexcept(cbegin(some_ints)), "");
-	static_assert(noexcept(cend(some_ints)), "");
-	static_assert(noexcept(empty(some_ints)), "");
-	static_assert(noexcept(data(some_ints)), "");
+	{
+		X::non_constexpr_array<int, 4> not_a_constant_expression{{0,1,2,3}};
+		static_assert(noexcept(begin(not_a_constant_expression)));
+		static_assert(noexcept(end(not_a_constant_expression)));
+		static_assert(noexcept(cbegin(not_a_constant_expression)));
+		static_assert(noexcept(cend(not_a_constant_expression)));
+		static_assert(noexcept(empty(not_a_constant_expression)));
+		static_assert(noexcept(data(not_a_constant_expression)));
+	}
 
 	constexpr bool output = false;
-	static_assert(!empty(some_ints), "");
+	static_assert(!empty(some_ints));
 	if (output) std::cout << '{';
 	auto is_first = true;
 	auto count = 0;

--- a/test/views/elements_view.cpp
+++ b/test/views/elements_view.cpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <map>
+#include <string_view>
 #include <unordered_map>
 
 #include "../catch.hpp"


### PR DESCRIPTION
This is the first of what will probably be a large set of changes to get (as close as we can) to C++20 conformance.

First up is removing forwarding_range and replacing it with a new borrowed_range opt-in trait. This is a large and scary change and affects some of the most fundamental concepts and functions in the library, including the definitions of ranges::begin() and ranges::end(), which can now call member begin() on rvalues provided they specialise enable_borrowed_range.