### PR TITLE
Add ssize() #87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,11 @@ else ()
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/memory/concepts.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/memory/temporary_vector.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/access.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/basic_range_types.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/begin_end.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/concepts.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/primitives.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/ranges/range_concept.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/views/range_adaptors.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/views/semiregular_box.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/common_reference.hpp

--- a/include/nanorange/detail/ranges/basic_range_types.hpp
+++ b/include/nanorange/detail/ranges/basic_range_types.hpp
@@ -1,0 +1,39 @@
+// nanorange/detail/ranges/basic_range_types.hpp
+//
+// Copyright (c) 2020 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_DETAIL_RANGES_BASIC_RANGE_TYPES_HPP_INCLUDED
+#define NANORANGE_DETAIL_RANGES_BASIC_RANGE_TYPES_HPP_INCLUDED
+
+#include <nanorange/detail/ranges/begin_end.hpp>
+#include <nanorange/detail/ranges/range_concept.hpp>
+
+NANO_BEGIN_NAMESPACE
+
+template <typename T>
+using iterator_t = decltype(ranges::begin(std::declval<T&>()));
+
+template <typename R>
+using sentinel_t =
+    std::enable_if_t<range<R>, decltype(ranges::end(std::declval<R&>()))>;
+
+template <typename R>
+using range_difference_t =
+    std::enable_if_t<range<R>, iter_difference_t<iterator_t<R>>>;
+
+template <typename R>
+using range_value_t = std::enable_if_t<range<R>, iter_value_t<iterator_t<R>>>;
+
+template <typename R>
+using range_reference_t =
+    std::enable_if_t<range<R>, iter_reference_t<iterator_t<R>>>;
+
+template <typename R>
+using range_rvalue_reference_t =
+    std::enable_if_t<range<R>, iter_rvalue_reference_t<iterator_t<R>>>;
+
+NANO_END_NAMESPACE
+
+#endif

--- a/include/nanorange/detail/ranges/concepts.hpp
+++ b/include/nanorange/detail/ranges/concepts.hpp
@@ -7,9 +7,11 @@
 #ifndef NANORANGE_DETAIL_RANGES_CONCEPTS_HPP_INCLUDED
 #define NANORANGE_DETAIL_RANGES_CONCEPTS_HPP_INCLUDED
 
+#include <nanorange/detail/ranges/basic_range_types.hpp>
 #include <nanorange/detail/ranges/begin_end.hpp>
 #include <nanorange/detail/ranges/borrowed_range.hpp>
 #include <nanorange/detail/ranges/primitives.hpp>
+#include <nanorange/detail/ranges/range_concept.hpp>
 
 #include <initializer_list>
 
@@ -35,21 +37,6 @@ NANO_END_NAMESPACE_STD
 
 NANO_BEGIN_NAMESPACE
 
-namespace detail {
-
-struct range_concept {
-    template <typename T>
-    auto requires_(T& t) -> decltype(
-        ranges::begin(t),
-        ranges::end(t)
-    );
-};
-
-}
-
-template <typename T>
-NANO_CONCEPT range = detail::requires_<detail::range_concept, T>;
-
 template <typename T>
 NANO_CONCEPT borrowed_range = range<T> &&
     (std::is_lvalue_reference_v<T> || enable_borrowed_range<remove_cvref_t<T>>);
@@ -58,29 +45,6 @@ NANO_CONCEPT borrowed_range = range<T> &&
 template <typename CharT, typename Traits>
 inline constexpr bool
     enable_borrowed_range<std::basic_string_view<CharT, Traits>> = true;
-
-template <typename T>
-using iterator_t = decltype(ranges::begin(std::declval<T&>()));
-
-template <typename R>
-using sentinel_t = std::enable_if_t<range<R>,
-    decltype(ranges::end(std::declval<R&>()))>;
-
-template <typename R>
-using range_difference_t = std::enable_if_t<range<R>,
-    iter_difference_t<iterator_t<R>>>;
-
-template <typename R>
-using range_value_t = std::enable_if_t<range<R>,
-    iter_value_t<iterator_t<R>>>;
-
-template <typename R>
-using range_reference_t = std::enable_if_t<range<R>,
-    iter_reference_t<iterator_t<R>>>;
-
-template <typename R>
-using range_rvalue_reference_t = std::enable_if_t<range<R>,
-    iter_rvalue_reference_t<iterator_t<R>>>;
 
 
 // [range.sized]

--- a/include/nanorange/detail/ranges/primitives.hpp
+++ b/include/nanorange/detail/ranges/primitives.hpp
@@ -11,7 +11,7 @@
 
 NANO_BEGIN_NAMESPACE
 
-// [range.primitives.size]
+// [range.prim.size]
 
 template <typename>
 inline constexpr bool disable_sized_range = false;
@@ -91,7 +91,7 @@ public:
 
 NANO_INLINE_VAR(detail::size_::fn, size)
 
-// [range.primitives.empty]
+// [range.prim.empty]
 
 namespace detail {
 namespace empty_ {

--- a/include/nanorange/detail/ranges/primitives.hpp
+++ b/include/nanorange/detail/ranges/primitives.hpp
@@ -7,6 +7,7 @@
 #ifndef NANORANGE_DETAIL_RANGES_PRIMITIVES_HPP_INCLUDED
 #define NANORANGE_DETAIL_RANGES_PRIMITIVES_HPP_INCLUDED
 
+#include <nanorange/detail/ranges/basic_range_types.hpp>
 #include <nanorange/detail/ranges/begin_end.hpp>
 
 NANO_BEGIN_NAMESPACE
@@ -90,6 +91,42 @@ public:
 } // namespace detail
 
 NANO_INLINE_VAR(detail::size_::fn, size)
+
+// [range.prim.ssize]
+
+namespace detail {
+namespace ssize_ {
+
+struct fn {
+private:
+    template <typename T>
+    using ssize_return_t =
+        std::conditional_t<sizeof(range_difference_t<T>) <
+                               sizeof(std::ptrdiff_t),
+                           std::ptrdiff_t, range_difference_t<T>>;
+
+    template <typename T>
+    static constexpr auto
+    impl(T&& t) noexcept(noexcept(ranges::size(std::forward<T>(t))))
+        -> decltype(ranges::size(std::forward<T>(t)), ssize_return_t<T>())
+    {
+        return static_cast<ssize_return_t<T>>(ranges::size(std::forward<T>(t)));
+    }
+
+public:
+    template <typename T>
+    constexpr auto operator()(T&& t) const
+        noexcept(noexcept(fn::impl(std::forward<T>(t))))
+            -> decltype(fn::impl(std::forward<T>(t)))
+    {
+        return fn::impl(std::forward<T>(t));
+    }
+};
+
+} // namespace ssize_
+} // namespace detail
+
+NANO_INLINE_VAR(detail::ssize_::fn, ssize)
 
 // [range.prim.empty]
 

--- a/include/nanorange/detail/ranges/range_concept.hpp
+++ b/include/nanorange/detail/ranges/range_concept.hpp
@@ -1,0 +1,28 @@
+// nanorange/detail/ranges/range_concept.hpp
+//
+// Copyright (c) 2020 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_DETAIL_RANGES_RANGE_CONCEPT_HPP_INCLUDED
+#define NANORANGE_DETAIL_RANGES_RANGE_CONCEPT_HPP_INCLUDED
+
+#include <nanorange/detail/ranges/begin_end.hpp>
+
+NANO_BEGIN_NAMESPACE
+
+namespace detail {
+
+struct range_concept {
+    template <typename T>
+    auto requires_(T& t) -> decltype(ranges::begin(t), ranges::end(t));
+};
+
+} // namespace detail
+
+template <typename T>
+NANO_CONCEPT range = detail::requires_<detail::range_concept, T>;
+
+NANO_END_NAMESPACE
+
+#endif

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -54,6 +54,7 @@ void test_initializer_list()
         }
     }
     CHECK(ranges::size(il) == std::size_t{3});
+    CHECK(ranges::ssize(il) == std::ptrdiff_t{3});
     CHECK(ranges::data(il) == &*il.begin());
     CHECK(ranges::empty(il) == false);
 }
@@ -75,6 +76,7 @@ void test_array(std::index_sequence<Is...>)
         }
     }
     CHECK(ranges::size(a) == sizeof...(Is));
+    CHECK(ranges::ssize(a) == sizeof...(Is));
     CHECK(ranges::data(a) == a + 0);
     CHECK(ranges::empty(a) == false);
 }
@@ -327,6 +329,8 @@ TEST_CASE("range_access") {
 	using namespace ranges;
 
 	static constexpr X::array<int, 4> some_ints = {{0,1,2,3}};
+
+	static_assert(ranges::signed_integral<decltype(ranges::ssize(some_ints))>);
 
 	constexpr auto first = begin(some_ints);
 	constexpr auto last = end(some_ints);


### PR DESCRIPTION
I added the `ssize` CPO as https://timsong-cpp.github.io/cppwp/range.prim.ssize .

I had to move stuff out of `concepts.hpp` to avoid circular dependencies with `primitives.hpp`, because `range_difference_t` was needed to deduce the return type of `ssize`. I'm not sure if i've followed your file structure correctly for this.

I've also changed the `range.primitives.*` comments to `range.prim.*` to follow the new name used for the standard (compared to the TS).

And good job for the lib, i like it !