### PR TITLE
Switch to new return types

### DIFF
--- a/include/nanorange/algorithm/count.hpp
+++ b/include/nanorange/algorithm/count.hpp
@@ -51,7 +51,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        iter_difference_t<iterator_t<Rng>>>
+        range_difference_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return count_if_fn::impl(nano::begin(rng), nano::end(rng),
@@ -82,7 +82,7 @@ struct count_fn {
         input_range<Rng> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,
-        iter_difference_t<iterator_t<Rng>>>
+        range_difference_t<Rng>>
     operator()(Rng&& rng, const T& value, Proj proj = Proj{}) const
     {
         const auto pred = [&value] (const auto& t) { return t == value; };

--- a/include/nanorange/algorithm/max.hpp
+++ b/include/nanorange/algorithm/max.hpp
@@ -63,7 +63,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> && copyable<iter_value_t<iterator_t<Rng>>> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-    iter_value_t<iterator_t<Rng>>>
+    range_value_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return max_fn::impl(std::forward<Rng>(rng), comp, proj);

--- a/include/nanorange/algorithm/min.hpp
+++ b/include/nanorange/algorithm/min.hpp
@@ -62,7 +62,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> && copyable<iter_value_t<iterator_t<Rng>>> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        iter_value_t<iterator_t<Rng>>>
+        range_value_t<Rng>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return min_fn::impl(std::forward<Rng>(rng), comp, proj);

--- a/include/nanorange/algorithm/minmax.hpp
+++ b/include/nanorange/algorithm/minmax.hpp
@@ -134,7 +134,7 @@ public:
     constexpr std::enable_if_t<
         input_range<Rng> && copyable<iter_value_t<iterator_t<Rng>>> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        minmax_result<iter_value_t<iterator_t<Rng>>>>
+        minmax_result<range_value_t<Rng>>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return minmax_fn::impl(std::forward<Rng>(rng), comp, proj);

--- a/include/nanorange/algorithm/minmax_element.hpp
+++ b/include/nanorange/algorithm/minmax_element.hpp
@@ -14,14 +14,17 @@
 
 NANO_BEGIN_NAMESPACE
 
+template <typename T>
+using minmax_element_result = minmax_result<T>;
+
 namespace detail {
 
 struct minmax_element_fn {
 private:
     template <typename I, typename S, typename Comp, typename Proj>
-    static constexpr minmax_result<I> impl(I first, S last, Comp& comp, Proj& proj)
+    static constexpr minmax_element_result<I> impl(I first, S last, Comp& comp, Proj& proj)
     {
-        minmax_result<I> result{first, first};
+        minmax_element_result<I> result{first, first};
 
         if (first == last || ++first == last) {
             return result;
@@ -84,7 +87,7 @@ public:
     constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>,
-        minmax_result<I>>
+        minmax_element_result<I>>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return minmax_element_fn::impl(std::move(first), std::move(last),
@@ -95,7 +98,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
-        minmax_result<borrowed_iterator_t<Rng>>>
+        minmax_element_result<borrowed_iterator_t<Rng>>>
     operator()(Rng&& rng, Comp comp = Comp{}, Proj proj = Proj{}) const
     {
         return minmax_element_fn::impl(nano::begin(rng), nano::end(rng),

--- a/include/nanorange/algorithm/partition.hpp
+++ b/include/nanorange/algorithm/partition.hpp
@@ -8,6 +8,7 @@
 #define NANORANGE_ALGORITHM_PARTITION_HPP_INCLUDED
 
 #include <nanorange/algorithm/find.hpp>
+#include <nanorange/views/subrange.hpp>
 
 NANO_BEGIN_NAMESPACE
 
@@ -16,32 +17,32 @@ namespace detail {
 struct partition_fn {
 private:
     template <typename I, typename S, typename Pred, typename Proj>
-    static constexpr I impl(I first, S last, Pred& pred, Proj& proj)
+    static constexpr subrange<I> impl(I first, S last, Pred& pred, Proj& proj)
     {
-        first = nano::find_if_not(std::move(first), last, pred, proj);
+        I it = nano::find_if_not(first, last, pred, proj);
 
-        if (first == last) {
-            return first;
+        if (it == last) {
+            return {std::move(it), std::move(nano::next(first, last))};
         }
 
-        auto n = nano::next(first);
+        auto n = nano::next(it);
 
         while (n != last) {
             if (nano::invoke(pred, nano::invoke(proj, *n))) {
-                nano::iter_swap(n, first);
-                ++first;
+                nano::iter_swap(n, it);
+                ++it;
             }
             ++n;
         }
 
-        return first;
+        return {std::move(it), std::move(n)};
     }
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
     constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
-            indirect_unary_predicate<Pred, projected<I, Proj>>, I>
+            indirect_unary_predicate<Pred, projected<I, Proj>>, subrange<I>>
     operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
     {
         return partition_fn::impl(std::move(first), std::move(last),
@@ -52,7 +53,7 @@ public:
     constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
-        borrowed_iterator_t<Rng>>
+        borrowed_subrange_t<Rng>>
     operator()(Rng&& rng, Pred pred, Proj proj = Proj{}) const
     {
         return partition_fn::impl(nano::begin(rng), nano::end(rng),

--- a/test/algorithm/partition.cpp
+++ b/test/algorithm/partition.cpp
@@ -44,30 +44,30 @@ test_iter()
 	// check mixed
 	int ia[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
-	Iter r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	auto r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + 5);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
 	for (int* i = base(r); i < ia + sa; ++i)
 		CHECK(!is_odd()(*i));
 	// check empty
-	r = stl2::partition(Iter(ia), Sent(ia), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia), is_odd()).begin();
 	CHECK(base(r) == ia);
 	// check all false
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia);
 	// check all true
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i + 1;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + sa);
 	// check all true but last
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i + 1;
 	ia[sa - 1] = 10;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -77,7 +77,7 @@ test_iter()
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i + 1;
 	ia[0] = 10;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -87,7 +87,7 @@ test_iter()
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i;
 	ia[sa - 1] = 11;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -97,7 +97,7 @@ test_iter()
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i;
 	ia[0] = 11;
-	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd());
+	r = stl2::partition(Iter(ia), Sent(ia + sa), is_odd()).begin();
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -114,7 +114,7 @@ test_range()
 	const unsigned sa = sizeof(ia) / sizeof(ia[0]);
 	Iter r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + 5);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -122,21 +122,21 @@ test_range()
 		CHECK(!is_odd()(*i));
 	// check empty
 	r = stl2::partition(::as_lvalue(stl2::subrange(Iter(ia), Sent(ia))),
-						is_odd());
+						is_odd()).begin();
 	CHECK(base(r) == ia);
 	// check all false
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia);
 	// check all true
 	for (unsigned i = 0; i < sa; ++i)
 		ia[i] = 2 * i + 1;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + sa);
 	// check all true but last
 	for (unsigned i = 0; i < sa; ++i)
@@ -144,7 +144,7 @@ test_range()
 	ia[sa - 1] = 10;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -156,7 +156,7 @@ test_range()
 	ia[0] = 10;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + sa - 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -168,7 +168,7 @@ test_range()
 	ia[sa - 1] = 11;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -180,7 +180,7 @@ test_range()
 	ia[0] = 11;
 	r = stl2::partition(
 			::as_lvalue(stl2::subrange(Iter(ia), Sent(ia + sa))),
-			is_odd());
+			is_odd()).begin();
 	CHECK(base(r) == ia + 1);
 	for (int* i = ia; i < base(r); ++i)
 		CHECK(is_odd()(*i));
@@ -215,7 +215,7 @@ TEST_CASE("alg.partition")
 	// Test projections
 	S ia[] = {S{1}, S{2}, S{3}, S{4}, S{5}, S{6}, S{7}, S{8} ,S{9}};
 	const unsigned sa = sizeof(ia)/sizeof(ia[0]);
-	S* r = stl2::partition(ia, is_odd(), &S::i);
+	S* r = stl2::partition(ia, is_odd(), &S::i).begin();
 	CHECK(r == ia + 5);
 	for (S* i = ia; i < r; ++i)
 		CHECK(is_odd()(i->i));
@@ -223,7 +223,7 @@ TEST_CASE("alg.partition")
 		CHECK(!is_odd()(i->i));
 
 	// Test rvalue range
-	auto r2 = stl2::partition(stl2::subrange(ia), is_odd(), &S::i);
+	auto r2 = stl2::partition(stl2::subrange(ia), is_odd(), &S::i).begin();
 	CHECK(r2 == ia + 5);
 	for (S* i = ia; i < r2; ++i)
 		CHECK(is_odd()(i->i));

--- a/test/algorithm/stable_partition.cpp
+++ b/test/algorithm/stable_partition.cpp
@@ -66,7 +66,7 @@ test_iter()
 				  {4, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -92,7 +92,7 @@ test_iter()
 				  {4, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -105,14 +105,14 @@ test_iter()
 		CHECK(ap[8] == P{4, 1});
 		CHECK(ap[9] == P{4, 2});
 		// check empty
-		r = ranges::stable_partition(Iter(ap), Sent(ap), odd_first());
+		r = ranges::stable_partition(Iter(ap), Sent(ap), odd_first()).begin();
 		CHECK(base(r) == ap);
 		// check one true
-		r = ranges::stable_partition(Iter(ap), Sent(ap + 1), odd_first());
+		r = ranges::stable_partition(Iter(ap), Sent(ap + 1), odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
 		// check one false
-		r = ranges::stable_partition(Iter(ap + 4), Sent(ap + 5), odd_first());
+		r = ranges::stable_partition(Iter(ap + 4), Sent(ap + 5), odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[4] == P{0, 1});
 	}
@@ -129,7 +129,7 @@ test_iter()
 				  {8, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap);
 		CHECK(ap[0] == P{0, 1});
 		CHECK(ap[1] == P{0, 2});
@@ -155,7 +155,7 @@ test_iter()
 				  {9, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + size);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -181,7 +181,7 @@ test_iter()
 				  {8, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{0, 2});
@@ -207,7 +207,7 @@ test_iter()
 				  {1, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 2});
 		CHECK(ap[1] == P{0, 1});
@@ -233,7 +233,7 @@ test_iter()
 				  {9, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 2});
 		CHECK(ap[1] == P{3, 1});
@@ -259,7 +259,7 @@ test_iter()
 				  {0, 2}};
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(Iter(ap), Sent(ap + size),
-										  odd_first());
+										  odd_first()).begin();
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -293,7 +293,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -320,7 +320,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -335,18 +335,18 @@ test_range()
 		// check empty
 		r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap);
 		// check one true
 		r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + 1))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
 		// check one false
 		r = ranges::stable_partition(::as_lvalue(
 				ranges::subrange(Iter(ap + 4), Sent(ap + 5))),
-									 odd_first());
+									 odd_first()).begin();
 		CHECK(base(r) == ap + 4);
 		CHECK(ap[4] == P{0, 1});
 	}
@@ -364,7 +364,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap);
 		CHECK(ap[0] == P{0, 1});
 		CHECK(ap[1] == P{0, 2});
@@ -391,7 +391,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + size);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -418,7 +418,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{0, 2});
@@ -445,7 +445,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + 1);
 		CHECK(ap[0] == P{1, 2});
 		CHECK(ap[1] == P{0, 1});
@@ -472,7 +472,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 2});
 		CHECK(ap[1] == P{3, 1});
@@ -499,7 +499,7 @@ test_range()
 		std::size_t size = ranges::size(ap);
 		Iter r = ranges::stable_partition(
 				::as_lvalue(ranges::subrange(Iter(ap), Sent(ap + size))),
-				odd_first());
+				odd_first()).begin();
 		CHECK(base(r) == ap + size - 1);
 		CHECK(ap[0] == P{1, 1});
 		CHECK(ap[1] == P{1, 2});
@@ -544,7 +544,7 @@ test_move_only()
 	const unsigned size = 5;
 	move_only array[size] = {1, 2, 3, 4, 5};
 	Iter r = ranges::stable_partition(Iter(array), Iter(array + size), is_odd{},
-									  &move_only::i);
+									  &move_only::i).begin();
 	CHECK(base(r) == array + 3);
 	CHECK(array[0].i == 1);
 	CHECK(array[1].i == 3);
@@ -587,7 +587,7 @@ TEST_CASE("alg.stable_partition")
 	using P = std::pair<int, int>;
 	{  // check mixed
 		S ap[] = { {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}, {{2, 2}}, {{3, 1}}, {{3, 2}}, {{4, 1}}, {{4, 2}} };
-		S* r = ranges::stable_partition(ap, odd_first(), &S::p);
+		S* r = ranges::stable_partition(ap, odd_first(), &S::p).begin();
 		CHECK(r == ap + 4);
 		CHECK(ap[0].p == P{1, 1});
 		CHECK(ap[1].p == P{1, 2});
@@ -624,7 +624,7 @@ TEST_CASE("alg.stable_partition")
 		int some_ints[] = {1, 0};
 		auto first = some_ints + 0, last = some_ints + 2;
 		auto even = [](int i) { return i % 2 == 0; };
-		ranges::stable_partition(first, last, even);
+		ranges::stable_partition(first, last, even).begin();
 		CHECK(std::is_partitioned(first, last, even));
 	}
 }

--- a/test/algorithm/unique.cpp
+++ b/test/algorithm/unique.cpp
@@ -73,14 +73,14 @@ void test()
 	{
 		int a[] = {0};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + sa));
 		CHECK(a[0] == 0);
 	}
 	{
 		int a[] = {0, 1};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + sa));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
@@ -88,14 +88,14 @@ void test()
 	{
 		int a[] = {0, 0};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 1));
 		CHECK(a[0] == 0);
 	}
 	{
 		int a[] = {0, 0, 1};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 2));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
@@ -103,7 +103,7 @@ void test()
 	{
 		int a[] = {0, 0, 1, 0};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 3));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
@@ -112,7 +112,7 @@ void test()
 	{
 		int a[] = {0, 0, 1, 1};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 2));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
@@ -120,7 +120,7 @@ void test()
 	{
 		int a[] = {0, 1, 1};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 2));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);
@@ -128,7 +128,7 @@ void test()
 	{
 		int a[] = {0, 1, 1, 1, 2, 2, 2};
 		const unsigned sa = sizeof(a) / sizeof(a[0]);
-		auto r = Fun{}(a, a + sa);
+		auto r = Fun{}(a, a + sa).begin();
 		CHECK(r == It(a + 3));
 		CHECK(a[0] == 0);
 		CHECK(a[1] == 1);

--- a/test/basic_algorithm/modifying_seq_ops.cpp
+++ b/test/basic_algorithm/modifying_seq_ops.cpp
@@ -558,8 +558,9 @@ TEST_CASE("alg.basic.unique")
     std::vector<int> vec{1, 2, 2, 3, 3, 3, 4, 4};
 
     SECTION("with iterators") {
-        const auto it = rng::unique(vec.begin(), vec.end());
-        REQUIRE(it == vec.begin() + 4);
+        const auto sub = rng::unique(vec.begin(), vec.end());
+        REQUIRE(sub.end() == vec.end());
+        REQUIRE(sub.begin() == vec.begin() + 4);
         REQUIRE(vec[0] == 1);
         REQUIRE(vec[1] == 2);
         REQUIRE(vec[2] == 3);
@@ -567,8 +568,9 @@ TEST_CASE("alg.basic.unique")
     }
 
     SECTION("with range") {
-        const auto it = rng::unique(vec);
-        REQUIRE(it == vec.begin() + 4);
+        const auto sub = rng::unique(vec);
+        REQUIRE(sub.end() == vec.end());
+        REQUIRE(sub.begin() == vec.begin() + 4);
         REQUIRE(vec[0] == 1);
         REQUIRE(vec[1] == 2);
         REQUIRE(vec[2] == 3);
@@ -581,8 +583,9 @@ TEST_CASE("alg.basic.unique (with predicate)")
     std::vector<int> vec{1, 2, 2, 3, 3, 3, 4, 4};
 
     SECTION("with iterators") {
-        const auto it = rng::unique(vec.begin(), vec.end(), std::equal_to<>{});
-        REQUIRE(it == vec.begin() + 4);
+        const auto sub = rng::unique(vec.begin(), vec.end(), std::equal_to<>{});
+        REQUIRE(sub.end() == vec.end());
+        REQUIRE(sub.begin() == vec.begin() + 4);
         REQUIRE(vec[0] == 1);
         REQUIRE(vec[1] == 2);
         REQUIRE(vec[2] == 3);
@@ -590,8 +593,9 @@ TEST_CASE("alg.basic.unique (with predicate)")
     }
 
     SECTION("with range") {
-        const auto it = rng::unique(vec, std::equal_to<>{});
-        REQUIRE(it == vec.begin() + 4);
+        const auto sub = rng::unique(vec, std::equal_to<>{});
+        REQUIRE(sub.end() == vec.end());
+        REQUIRE(sub.begin() == vec.begin() + 4);
         REQUIRE(vec[0] == 1);
         REQUIRE(vec[1] == 2);
         REQUIRE(vec[2] == 3);


### PR DESCRIPTION
This commit changes the return types of some algorithms, according to
the `<algorithm>` header synopsis on cppreference.

For the following algorithms I am actually not sure if what I'm returning is correct:

- `partial_sort_copy` now returns (an alias to) `copy_result<I, O>`.
- `partition`, `stable_partition` and `unique` now return `subrange<I>`.

In all cases I'm not 100% sure I'm returning the right value. Also, I've done the bare minimum with the tests to get them to compile and run. That means that I'm only testing the `O` from the `partial_sort_copy_result` and only `end()` of `subrange<I>`, which is what used to be tested before my pull request.