### PR TITLE
Implement clamp, for_each_n and sample algorithms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else ()
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/all_of.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/any_of.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/binary_search.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/clamp.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/copy.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/count.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/equal.hpp
@@ -88,6 +89,7 @@ else ()
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/set_intersection.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/set_symmetric_difference.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/set_union.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/sample.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/shuffle.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/sort.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/algorithm/sort_heap.hpp

--- a/include/nanorange/algorithm.hpp
+++ b/include/nanorange/algorithm.hpp
@@ -12,6 +12,7 @@
 #include <nanorange/algorithm/all_of.hpp>
 #include <nanorange/algorithm/any_of.hpp>
 #include <nanorange/algorithm/binary_search.hpp>
+#include <nanorange/algorithm/clamp.hpp>
 #include <nanorange/algorithm/copy.hpp>
 #include <nanorange/algorithm/count.hpp>
 #include <nanorange/algorithm/equal.hpp>
@@ -73,6 +74,7 @@
 #include <nanorange/algorithm/set_intersection.hpp>
 #include <nanorange/algorithm/set_symmetric_difference.hpp>
 #include <nanorange/algorithm/set_union.hpp>
+#include <nanorange/algorithm/sample.hpp>
 #include <nanorange/algorithm/shuffle.hpp>
 #include <nanorange/algorithm/sort.hpp>
 #include <nanorange/algorithm/sort_heap.hpp>

--- a/include/nanorange/algorithm/clamp.hpp
+++ b/include/nanorange/algorithm/clamp.hpp
@@ -1,0 +1,37 @@
+// nanorange/algorithm/clamp.hpp
+//
+// Copyright (c) 2020 Boris Staletic (boris dot staletic at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_ALGORITHM_CLAMP_HPP_INCLUDED
+#define NANORANGE_ALGORITHM_CLAMP_HPP_INCLUDED
+
+#include <nanorange/ranges.hpp>
+
+NANO_BEGIN_NAMESPACE
+
+namespace detail {
+
+struct clamp_fn {
+    template <typename T, typename Proj = identity, typename Comp = nano::less>
+    constexpr std::enable_if_t<indirect_strict_weak_order<Comp, projected<const T*, Proj>>, const T&>
+    operator()(const T& value, const T& low, const T& high, Comp comp = {}, Proj proj = Proj{}) const
+    {
+        auto&& projected_value = nano::invoke(proj, value);
+        if (nano::invoke(comp, projected_value, nano::invoke(proj, low))) {
+            return low;
+        } else if (nano::invoke(comp, nano::invoke(proj, high), projected_value)) {
+            return high;
+        } else {
+            return value;
+        }
+    }
+};
+} // namespace detail
+
+NANO_INLINE_VAR(detail::clamp_fn, clamp)
+
+NANO_END_NAMESPACE
+
+#endif

--- a/include/nanorange/algorithm/for_each.hpp
+++ b/include/nanorange/algorithm/for_each.hpp
@@ -77,6 +77,30 @@ public:
 
 NANO_INLINE_VAR(detail::for_each_fn, for_each)
 
+template <typename I, typename F>
+using for_each_n_result = for_each_result<I, F>;
+
+namespace detail {
+
+struct for_each_n_fn {
+    template <typename I, typename Proj = identity, typename Fun>
+    constexpr std::enable_if_t<
+        input_iterator<I> &&
+            indirect_unary_invocable<Fun, projected<I, Proj>>,
+        for_each_n_result<I, Fun>>
+    operator()(I first, iter_difference_t<I> n, Fun fun, Proj proj = Proj{}) const
+    {
+        while (n-- > 0) {
+            nano::invoke(fun, nano::invoke(proj, *first));
+            ++first;
+        }
+        return {std::move(first), std::move(fun)};
+    }
+};
+} // namespace detail
+
+NANO_INLINE_VAR(detail::for_each_n_fn, for_each_n)
+
 NANO_END_NAMESPACE
 
 #endif

--- a/include/nanorange/algorithm/sample.hpp
+++ b/include/nanorange/algorithm/sample.hpp
@@ -1,0 +1,118 @@
+// nanorange/algorithm/sample.hpp
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NANORANGE_ALGORITHM_SAMPLE_HPP_INCLUDED
+#define NANORANGE_ALGORITHM_SAMPLE_HPP_INCLUDED
+
+#include <nanorange/ranges.hpp>
+#include <nanorange/random.hpp>
+#include <nanorange/algorithm/min.hpp>
+
+#include <random>
+
+NANO_BEGIN_NAMESPACE
+
+namespace detail {
+
+struct sample_fn {
+private:
+    template <typename I, typename S, typename O, typename Gen>
+    static O impl_fwd(I first, S last, O out, iter_difference_t<I> n, Gen& g)
+    {
+        using diff_t = iter_difference_t<I>;
+        using distr_t = std::uniform_int_distribution<diff_t>;
+        using param_t = typename distr_t::param_type;
+
+        distr_t D;
+
+        auto unsampled_size = nano::distance(first, last);
+
+        for (n = nano::min(n, unsampled_size); n != 0; ++first) {
+            if (D(g, param_t(0, --unsampled_size)) < n) {
+                *out++ = *first;
+                --n;
+            }
+        }
+
+        return out;
+    }
+    template <typename I, typename S, typename O, typename Gen>
+    static O impl_ra(I first, S last, O out, iter_difference_t<I> n, Gen& g) {
+        using diff_t = iter_difference_t<I>;
+        using distr_t = std::uniform_int_distribution<diff_t>;
+        using param_t = typename distr_t::param_type;
+
+        distr_t D;
+        diff_t k = 0;
+
+        for(; first != last && k < n; ++first, (void) ++k) {
+            out[k] = *first;
+        }
+
+        diff_t size = k;
+        for (; first != last; ++first, (void) ++k) {
+            diff_t r = distr_t(0, k)(g);
+            if (D(g, param_t(0, k)) < size) {
+                out[r] = *first;
+            }
+        }
+
+        return out + nano::min(n, k);
+    }
+
+    template <typename I, typename S, typename O, typename Gen>
+    static O impl(I first, S last, O out, iter_difference_t<I> n, Gen& g)
+    {
+        if constexpr (nano::forward_iterator<I>) {
+            return impl_fwd(std::move(first), std::move(last), std::move(out), n, g);
+	} else {
+            return impl_ra(std::move(first), std::move(last), std::move(out), n, g);
+	}
+    }
+
+public:
+    template <typename I, typename S, typename O, typename Gen>
+    std::enable_if_t<
+        input_iterator<I> &&
+        sentinel_for<S, I> &&
+        weakly_incrementable<O> &&
+        (forward_iterator<I> || random_access_iterator<O>) &&
+        indirectly_copyable<I, O> &&
+        uniform_random_bit_generator<std::remove_reference_t<Gen>>,
+        O>
+    operator()(I first, S last, O out, iter_difference_t<I> n, Gen&& gen) const
+    {
+        return sample_fn::impl(std::move(first), std::move(last),
+                               std::move(out), std::move(n),
+                               std::forward<Gen>(gen));
+    }
+
+    template <typename Rng, typename O, typename Gen>
+    std::enable_if_t<
+        input_range<Rng> &&
+        weakly_incrementable<O> &&
+        (forward_range<Rng> || random_access_iterator<O> ) &&
+        indirectly_copyable<iterator_t<Rng>, O> &&
+        uniform_random_bit_generator<std::remove_reference_t<Gen>>,
+        O>
+    operator()(Rng&& rng, O out, range_difference_t<Rng> n, Gen&& gen) const
+    {
+        return sample_fn::impl(nano::begin(rng), nano::end(rng),
+                               std::move(out), std::move(n), std::forward<Gen>(gen));
+    }
+};
+
+}
+
+NANO_INLINE_VAR(detail::sample_fn, sample)
+
+NANO_END_NAMESPACE
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(test_nanorange
     basic_algorithm/sorting_ops.cpp
 
     # Constexpr tests for algorithms
+    constexpr_algorithm/non_modifying_seq_ops.cpp
     constexpr_algorithm/modifying_seq_ops.cpp
     constexpr_algorithm/permutation_ops.cpp
     constexpr_algorithm/sorting_ops.cpp
@@ -24,6 +25,7 @@ add_executable(test_nanorange
     algorithm/all_of.cpp
     algorithm/any_of.cpp
     algorithm/binary_search.cpp
+    algorithm/clamp.cpp
     algorithm/copy.cpp
     algorithm/copy_backward.cpp
     algorithm/copy_if.cpp
@@ -40,6 +42,7 @@ add_executable(test_nanorange
     algorithm/find_if.cpp
     algorithm/find_if_not.cpp
     algorithm/for_each.cpp
+    algorithm/for_each_n.cpp
     algorithm/generate.cpp
     algorithm/generate_n.cpp
     algorithm/includes.cpp
@@ -92,7 +95,7 @@ add_executable(test_nanorange
     algorithm/reverse_copy.cpp
     algorithm/rotate.cpp
     algorithm/rotate_copy.cpp
-    #algorithm/sample.cpp
+    algorithm/sample.cpp
     algorithm/search.cpp
     algorithm/search_n.cpp
     algorithm/set_difference1.cpp

--- a/test/algorithm/clamp.cpp
+++ b/test/algorithm/clamp.cpp
@@ -1,0 +1,168 @@
+// nanorange/algorithm/clamp.hpp
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <nanorange/algorithm/clamp.hpp>
+
+#include "../catch.hpp"
+
+namespace ranges = nano;
+
+struct Tag {
+	Tag() : val(0), tag("Default") {}
+	Tag(int a, const char *b) : val(a), tag(b) {}
+	~Tag() {}
+
+	int val;
+	const char *tag;
+};
+
+TEST_CASE("alg.clamp")
+{
+	{
+		// Default comparison and projection
+		{
+			int value = 0;
+			int low = 0;
+			int high = 0;
+			CHECK(&nano::clamp(value, low, high) == &value);
+			CHECK(&nano::clamp(low, value, high) == &low);
+		}
+		{
+			int value = 0;
+			int low = 1;
+			int high = 2;
+			CHECK(&nano::clamp(value, low, high) == &low);
+			CHECK(&nano::clamp(low, value, high) == &low);
+		}
+		{
+			int value = 1;
+			int low = 0;
+			int high = 1;
+			CHECK(&nano::clamp(value, low, high) == &value);
+			CHECK(&nano::clamp(low, value, high) == &value);
+		}
+	}
+	{
+		// Custom comparison, default projection
+		{
+			//  If they're all the same, we should get the value back.
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{0, "Zero-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{0, "Zero-z"};
+			CHECK(&nano::clamp(x, y, z, comp) ==  &x);
+			CHECK(&nano::clamp(y, x, z, comp) ==  &y);
+		}
+
+		{
+			//  If it's the same as the lower bound, we get the value back.
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{0, "Zero-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, comp) == &x);
+			CHECK(&nano::clamp(y, x, z, comp) == &y);
+		}
+
+		{
+			//  If it's the same as the upper bound, we get the value back.
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{1, "One-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, comp) == &x);
+			CHECK(&nano::clamp(z, y, x, comp) == &z);
+		}
+
+		{
+			//  If the value is between, we should get the value back
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{1, "One-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{2, "Two-z"};
+			CHECK(&nano::clamp(x, y, z, comp) == &x);
+			CHECK(&nano::clamp(y, x, z, comp) == &x);
+		}
+
+		{
+			//  If the value is less than the 'lo', we should get the lo back.
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{0, "Zero-x"};
+			Tag y{1, "One-y"};
+			Tag z{2, "Two-z"};
+			CHECK(&nano::clamp(x, y, z, comp) == &y);
+			CHECK(&nano::clamp(y, x, z, comp) == &y);
+		}
+		{
+			//  If the value is greater than 'hi', we should get hi back.
+			auto comp = [](const Tag& a, const Tag& b) { return a.val < b.val; };
+			Tag x{2, "Two-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, comp) == &z);
+			CHECK(&nano::clamp(y, z, x, comp) == &z);
+		}
+	}
+	{
+		// Default comparison, custom projection
+		{
+			//  If they're all the same, we should get the value back.
+			Tag x{0, "Zero-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{0, "Zero-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) ==  &x);
+			CHECK(&nano::clamp(y, x, z, {}, &Tag::val) ==  &y);
+		}
+
+		{
+			//  If it's the same as the lower bound, we get the value back.
+			Tag x{0, "Zero-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) == &x);
+			CHECK(&nano::clamp(y, x, z, {}, &Tag::val) == &y);
+		}
+
+		{
+			//  If it's the same as the upper bound, we get the value back.
+			Tag x{1, "One-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) == &x);
+			CHECK(&nano::clamp(z, y, x, {}, &Tag::val) == &z);
+		}
+
+		{
+			//  If the value is between, we should get the value back
+			Tag x{1, "One-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{2, "Two-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) == &x);
+			CHECK(&nano::clamp(y, x, z, {}, &Tag::val) == &x);
+		}
+
+		{
+			//  If the value is less than the 'lo', we should get the lo back.
+			Tag x{0, "Zero-x"};
+			Tag y{1, "One-y"};
+			Tag z{2, "Two-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) == &y);
+			CHECK(&nano::clamp(y, x, z, {}, &Tag::val) == &y);
+		}
+		{
+			//  If the value is greater than 'hi', we should get hi back.
+			Tag x{2, "Two-x"};
+			Tag y{0, "Zero-y"};
+			Tag z{1, "One-z"};
+			CHECK(&nano::clamp(x, y, z, {}, &Tag::val) == &z);
+			CHECK(&nano::clamp(y, z, x, {}, &Tag::val) == &z);
+		}
+	}
+}

--- a/test/algorithm/for_each_n.cpp
+++ b/test/algorithm/for_each_n.cpp
@@ -1,0 +1,54 @@
+// Range v3 library
+//
+//  Copyright Eric Niebler 2014-present
+//  Copyright Rostislav Khlebnikov 2017
+//
+//  Use, modification and distribution is subject to the
+//  Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+// Project home: https://github.com/ericniebler/range-v3
+
+#include <nanorange/algorithm/for_each.hpp>
+#include <nanorange/views/subrange.hpp>
+#include <vector>
+#include "../catch.hpp"
+#include "../test_utils.hpp"
+
+namespace stl2 = nano;
+
+namespace {
+
+struct S {
+	void p() const { *p_ += i_; }
+
+	int *p_;
+	int i_;
+};
+
+}
+
+TEST_CASE("alg.for_each_n")
+{
+	int sum = 0;
+	auto fun = [&](int i){ sum += i; };
+	std::vector<int> v1 { 1, 2, 4, 6 };
+	CHECK(stl2::for_each_n(v1.begin(), 2, fun).in == v1.begin() + 2);
+	CHECK(sum == 3);
+
+	sum = 0;
+	auto rfun = [&](int& i){ sum += i; };
+	auto const sz = static_cast<int>(v1.size());
+	CHECK(stl2::for_each_n(v1.begin(), sz, rfun).in == v1.end());
+	CHECK(sum == 13);
+
+	sum = 0;
+	std::vector<S> v2{{&sum, 1}, {&sum, 2}, {&sum, 4}, {&sum, 6}};
+	CHECK(stl2::for_each_n(v2.begin(), 3, &S::p).in == v2.begin() + 3);
+	CHECK(sum == 7);
+
+	sum = 0;
+	CHECK(stl2::for_each_n(v2.begin(), 4, fun, &S::i_).in == v2.end());
+	CHECK(sum == 13);
+}

--- a/test/algorithm/sample.cpp
+++ b/test/algorithm/sample.cpp
@@ -23,36 +23,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stl2/detail/algorithm/sample.hpp>
+#include <nanorange/algorithm/sample.hpp>
 
 #include <array>
 #include <numeric>
-#include <stl2/detail/algorithm/equal.hpp>
-#include "../simple_test.hpp"
+#include <nanorange/algorithm/equal.hpp>
+#include <nanorange/iterator/move_iterator.hpp>
 #include "../test_utils.hpp"
 #include "../test_iterators.hpp"
 
-namespace ranges = __stl2;
+namespace ranges = nano::ranges;
 
-namespace {
-	ranges::Sentinel{S, I}
-	bool in_sequence(I first, I mid, S last)
-	{
-		for (; first != mid; ++first)
-			STL2_ASSERT(first != last);
-		for (; first != last; ++first)
-			;
-		return true;
-	}
-
-	struct MoveOnly {
-		MoveOnly() = default;
-		MoveOnly(MoveOnly&&) = default;
-		MoveOnly& operator=(MoveOnly&&) & = default;
-	};
-}
-
-int main()
+TEST_CASE("alg.sample")
 {
 	constexpr unsigned N = 100;
 	constexpr unsigned K = 10;
@@ -65,23 +47,20 @@ int main()
 		{
 			auto result = ranges::sample(random_access_iterator<int*>(i.data()),
 				sentinel<int*>(i.data()+N), a.begin(), K, g1);
-			CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
-			CHECK(result.out() == a.end());
+			CHECK(result == a.begin() + K);
 			CHECK(!ranges::equal(a, c));
 		}
 
 		{
 			auto result = ranges::sample(i.begin(), i.end(), b.begin(), K, g1);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
+			CHECK(result == b.begin() + K);
 			CHECK(!ranges::equal(a, b));
 			CHECK(!ranges::equal(b, c));
 		}
 
 		{
 			auto result = ranges::sample(i.begin(), i.end(), c.begin(), K, g2);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == c.end());
+			CHECK(result == c.begin() + K);
 			CHECK(ranges::equal(a, c));
 		}
 	}
@@ -91,26 +70,23 @@ int main()
 		std::iota(std::begin(i), std::end(i), 0);
 		std::array<int, K> a{}, b{}, c{};
 		std::minstd_rand g1, g2 = g1;
-		auto rng = ranges::ext::make_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
+		auto rng = ranges::subrange(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
 
 		{
 			auto result = ranges::sample(rng, a.begin(), K, g1);
-			CHECK(in_sequence(ranges::begin(rng), result.in(), ranges::end(rng)));
-			CHECK(result.out() == a.end());
+			CHECK(result == a.end());
 			CHECK(!ranges::equal(a, b));
 		}
 
 		{
 			auto result = ranges::sample(i, b.begin(), K, g2);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
+			CHECK(result == b.end());
 			CHECK(ranges::equal(a, b));
 		}
 
 		{
 			auto result = ranges::sample(i, b.begin(), K, g1);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
+			CHECK(result == b.end());
 			CHECK(!ranges::equal(a, b));
 			CHECK(!ranges::equal(b, c));
 		}
@@ -118,163 +94,8 @@ int main()
 		{
 			a.fill(0);
 			auto result = ranges::sample(std::move(rng), a.begin(), K, g1);
-			CHECK(in_sequence(ranges::begin(rng), result.in().get_unsafe(), ranges::end(rng)));
-			CHECK(result.out() == a.end());
+			CHECK(result == a.end());
 			CHECK(!ranges::equal(a, c));
 		}
 	}
-
-	{
-		std::array<int, N> i;
-		std::iota(std::begin(i), std::end(i), 0);
-		std::array<int, K> a{}, b{}, c{};
-
-		{
-			auto result = ranges::sample(random_access_iterator<int*>(i.data()),
-				sentinel<int*>(i.data() + N), a.begin(), K);
-			CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
-			CHECK(result.out() == a.end());
-			CHECK(!ranges::equal(a, b));
-		}
-
-		{
-			auto result = ranges::sample(i, b.begin(), K);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
-			CHECK(!ranges::equal(b, c));
-			CHECK(!ranges::equal(a, b));
-		}
-	}
-
-	{
-		std::array<MoveOnly, 10> source;
-		std::array<MoveOnly, 4> dest;
-		auto result = ranges::sample(ranges::make_move_iterator(source.begin()),
-			ranges::make_move_sentinel(source.end()),
-			forward_iterator<MoveOnly*>(dest.data()), dest.size());
-		CHECK(in_sequence(ranges::make_move_iterator(source.begin()),
-			result.in(),
-			ranges::make_move_sentinel(source.end())));
-		CHECK(result.out() == forward_iterator<MoveOnly*>(dest.data() + dest.size()));
-	}
-
-	{
-		std::array<int, N> i;
-		std::iota(std::begin(i), std::end(i), 0);
-		std::array<int, K> a{}, b{}, c{};
-		std::minstd_rand g1, g2 = g1;
-
-		{
-			auto result = ranges::sample(random_access_iterator<int*>(i.data()),
-				sentinel<int*>(i.data()+N), a, g1);
-			CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
-			CHECK(result.out() == a.end());
-			CHECK(!ranges::equal(a, c));
-		}
-
-		{
-			auto result = ranges::sample(i.begin(), i.end(), b, g1);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
-			CHECK(!ranges::equal(a, b));
-			CHECK(!ranges::equal(b, c));
-		}
-
-		{
-			auto result = ranges::sample(i.begin(), i.end(), c, g2);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == c.end());
-			CHECK(ranges::equal(a, c));
-		}
-	}
-
-	{
-		std::array<int, N> i;
-		std::iota(std::begin(i), std::end(i), 0);
-		std::array<int, K> a{}, b{}, c{};
-		std::minstd_rand g1, g2 = g1;
-		auto rng = ranges::ext::make_range(random_access_iterator<int*>(i.data()), sentinel<int*>(i.data() + N));
-
-		{
-			auto result = ranges::sample(rng, a, g1);
-			CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
-			CHECK(result.out() == a.end());
-			CHECK(!ranges::equal(a, b));
-		}
-
-		{
-			auto result = ranges::sample(i, b, g2);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
-			CHECK(ranges::equal(a, b));
-		}
-
-		{
-			auto result = ranges::sample(i, b, g1);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
-			CHECK(!ranges::equal(a, b));
-			CHECK(!ranges::equal(b, c));
-		}
-
-		{
-			a.fill(0);
-			auto result = ranges::sample(std::move(rng), a, g1);
-			CHECK(in_sequence(i.data(), result.in().get_unsafe().base(), i.data() + N));
-			CHECK(result.out() == a.end());
-			CHECK(!ranges::equal(a, c));
-		}
-	}
-
-	{
-		std::array<int, N> i;
-		std::iota(std::begin(i), std::end(i), 0);
-		std::array<int, K> a{}, b{}, c{};
-
-		{
-			auto result = ranges::sample(random_access_iterator<int*>(i.data()),
-				sentinel<int*>(i.data() + N), a);
-			CHECK(in_sequence(i.data(), result.in().base(), i.data() + N));
-			CHECK(result.out() == a.end());
-			CHECK(!ranges::equal(a, b));
-		}
-
-		{
-			auto result = ranges::sample(i, b);
-			CHECK(in_sequence(i.begin(), result.in(), i.end()));
-			CHECK(result.out() == b.end());
-			CHECK(!ranges::equal(b, c));
-			CHECK(!ranges::equal(a, b));
-		}
-	}
-
-	{
-		std::array<MoveOnly, 10> source;
-		std::array<MoveOnly, 4> dest;
-		auto out = ranges::ext::make_range(
-			forward_iterator<MoveOnly*>(dest.data()),
-			sentinel<MoveOnly*, true>(dest.data() + dest.size()));
-		auto result = ranges::sample(ranges::make_move_iterator(source.begin()),
-			ranges::make_move_sentinel(source.end()), out);
-		CHECK(in_sequence(source.data(), result.in().base(), source.data() + source.size()));
-		CHECK(result.out() == ranges::end(out));
-	}
-
-	{
-		int data[] = {0,1,2,3};
-		int sample[2];
-		std::minstd_rand g;
-		{
-			auto result = ranges::sample(data, sample, g);
-			CHECK(in_sequence(ranges::begin(data), result.in(), ranges::end(data)));
-			CHECK(result.out() == ranges::end(sample));
-		}
-		{
-			auto result = ranges::sample(data, sample);
-			CHECK(in_sequence(ranges::begin(data), result.in(), ranges::end(data)));
-			CHECK(result.out() == ranges::end(sample));
-		}
-	}
-
-	return ::test_result();
 }

--- a/test/basic_algorithm/modifying_seq_ops.cpp
+++ b/test/basic_algorithm/modifying_seq_ops.cpp
@@ -536,6 +536,26 @@ TEST_CASE("alg.basic.rotate_copy")
     }
 }
 
+TEST_CASE("alg.basic.sample")
+{
+    const std::vector<int> orig{1, 2, 3, 4, 5};
+    std::vector<int> vec(orig);
+    std::mt19937 rng{std::random_device{}()};
+    std::vector<int> out;
+
+    SECTION("with iterators") {
+	out.clear();
+        rng::sample(vec.begin(), vec.end(), nano::back_inserter(out), 2, rng);
+        REQUIRE(out.size() == 2);
+    }
+
+    SECTION("with range") {
+	out.clear();
+        rng::sample(vec, nano::back_inserter(out), 2, rng);
+        REQUIRE(out.size() == 2);
+    }
+}
+
 TEST_CASE("alg.basic.shuffle")
 {
     const std::vector<int> orig{1, 2, 3, 4, 5};

--- a/test/basic_algorithm/non_modifying_seq_ops.cpp
+++ b/test/basic_algorithm/non_modifying_seq_ops.cpp
@@ -68,6 +68,27 @@ TEST_CASE("alg.basic.for_each")
     REQUIRE(sum == 6);
 }
 
+TEST_CASE("alg.basic.for_each_n")
+{
+    struct functor {
+        int& sum;
+        int counter = 0;
+        void operator()(int i) /*not-const*/ {
+            sum += i;
+            ++counter;
+        }
+    };
+
+    constexpr std::array<int, 3> arr{{1, 2, 3}};
+    int sum = 0;
+    const auto func = functor{sum};
+
+    const auto func2 = rng::for_each_n(arr.begin(), 2, func);
+    REQUIRE(func2.in == arr.begin() + 2);
+    REQUIRE(func2.fun.counter == 2);
+    REQUIRE(sum == 3);
+}
+
 TEST_CASE("alg.basic.count")
 {
     constexpr std::array<int, 3> arr = {{2, 2, 2}};

--- a/test/buildfile
+++ b/test/buildfile
@@ -4,7 +4,6 @@
 # Skip broken tests and things we haven't implemented yet
 exe{test-nanorange}: cxx{**\
     -test_type_traits           \
-    -algorithm/sample           \
     -iterator/incomplete        \
     -iterator/iterator          \
     -views/indirect_view         \

--- a/test/constexpr_algorithm/non_modifying_seq_ops.cpp
+++ b/test/constexpr_algorithm/non_modifying_seq_ops.cpp
@@ -1,0 +1,76 @@
+
+#include <nanorange/algorithm.hpp>
+
+#include "constexpr_array.hpp"
+
+namespace {
+
+struct sum_fn {
+    int sum = 0;
+    constexpr void operator() (int e) {
+        sum += e;
+    }
+};
+
+constexpr bool test_for_each()
+{
+    constexpr carray<int, 3> arr{3, 2, 1};
+
+    {
+        auto result = nano::for_each(arr.begin(), arr.end(), sum_fn{});
+        if (result.fun.sum != 6) {
+            return false;
+        }
+    }
+
+    {
+        auto result = nano::for_each(arr, sum_fn{});
+        if (result.fun.sum != 6) {
+            return false;
+        }
+    }
+
+    {
+        auto result = nano::for_each(arr, sum_fn{}, [](int e) { return -e; });
+        if (result.fun.sum != -6) {
+            return false;
+        }
+    }
+
+    return true;
+}
+static_assert(test_for_each(), "");
+
+constexpr bool test_for_each_n()
+{
+    constexpr carray<int, 3> arr{3, 2, 1};
+
+    {
+        auto result = nano::for_each_n(arr.begin(), 2, sum_fn{}, [](int e) { return -e; });
+        if (result.fun.sum != -5) {
+            return false;
+        }
+    }
+    return true;
+}
+static_assert(test_for_each_n(), "");
+
+constexpr bool test_clamp()
+{
+    if (nano::clamp(1, 2, 5) != 2) {
+        return false;
+    }
+    if (nano::clamp(3, 2, 5) != 3) {
+        return false;
+    }
+    if (nano::clamp(7, 2, 5) != 5) {
+        return false;
+    }
+    if (nano::clamp(3, 2, 5, nano::greater{}, [](int i) { return -i; }) != 3) {
+        return false;
+    }
+    return true;
+}
+static_assert(test_clamp(), "");
+
+}


### PR DESCRIPTION
`sample` has a constraint that says `(forward_iterator<I> || random_access_iterator<O>)`. I was looking at [the C++17 `sample` implementation in libc++](https://github.com/llvm/llvm-project/blob/master/libcxx/include/algorithm#L3138-L3177) and only implemented the `forward_iterator` version. Should I do what libc++ is doing all the way?

&nbsp;

The tests for `clamp` were derived from [the libc++ tests](https://github.com/llvm/llvm-project/blob/master/libcxx/test/std/algorithms/alg.sorting/alg.clamp/clamp.pass.cpp). Should that be reflected in the copyright header of the `clamp.cpp`?