### PR TITLE
Implement [algorithms.results]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ else ()
 
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/algorithm/heap_sift.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/algorithm/pdqsort.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/algorithm/result_types.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/concepts/comparison.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/concepts/core.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/nanorange/detail/concepts/object.hpp

--- a/include/nanorange/algorithm/copy.hpp
+++ b/include/nanorange/algorithm/copy.hpp
@@ -7,32 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_COPY_HPP_INCLUDED
 
-#include <nanorange/iterator/operations.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-struct copy_result {
-    NANO_NO_UNIQUE_ADDRESS I in;
-    NANO_NO_UNIQUE_ADDRESS O out;
-
-    template <typename I2, typename O2,
-              std::enable_if_t<convertible_to<const I&, I2> &&
-                               convertible_to<const O&, O2>, int> = 0>
-    constexpr operator copy_result<I2, O2>() const &
-    {
-        return {in, out};
-    }
-
-    template <typename I2, typename O2,
-              std::enable_if_t<convertible_to<I, I2> &&
-                               convertible_to<O, O2>, int> = 0>
-    constexpr operator copy_result<I2, O2>() &&
-    {
-        return {std::move(in), std::move(out)};
-    }
-};
+using copy_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -96,7 +77,7 @@ public:
 NANO_INLINE_VAR(detail::copy_fn, copy)
 
 template <typename I, typename O>
-using copy_n_result = copy_result<I, O>;
+using copy_n_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -122,7 +103,7 @@ struct copy_n_fn {
 NANO_INLINE_VAR(detail::copy_n_fn, copy_n)
 
 template <typename I, typename O>
-using copy_if_result = copy_result<I, O>;
+using copy_if_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -176,7 +157,7 @@ public:
 NANO_INLINE_VAR(detail::copy_if_fn, copy_if)
 
 template <typename I, typename O>
-using copy_backward_result = copy_result<I, O>;
+using copy_backward_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/for_each.hpp
+++ b/include/nanorange/algorithm/for_each.hpp
@@ -7,6 +7,7 @@
 #ifndef NANORANGE_ALGORITHM_FOR_EACH_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_FOR_EACH_HPP_INCLUDED
 
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
@@ -14,26 +15,7 @@ NANO_BEGIN_NAMESPACE
 // [range.alg.foreach]
 
 template <typename I, typename F>
-struct for_each_result {
-    NANO_NO_UNIQUE_ADDRESS I in;
-    NANO_NO_UNIQUE_ADDRESS F fun;
-
-    template <typename I2, typename F2,
-              std::enable_if_t<convertible_to<const I&, I2> &&
-                               convertible_to<const F&, F2>, int> = 0>
-    constexpr operator for_each_result<I2, F2>() const &
-    {
-        return {in, fun};
-    }
-
-    template <typename I2, typename F2,
-        std::enable_if_t<convertible_to<I, I2> &&
-                         convertible_to<F, F2>, int> = 0>
-    constexpr operator for_each_result<I2, F2>() &&
-    {
-        return {std::move(in), std::move(fun)};
-    }
-};
+using for_each_result = in_fun_result<I, F>;
 
 namespace detail {
 
@@ -78,7 +60,7 @@ public:
 NANO_INLINE_VAR(detail::for_each_fn, for_each)
 
 template <typename I, typename F>
-using for_each_n_result = for_each_result<I, F>;
+using for_each_n_result = in_fun_result<I, F>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/merge.hpp
+++ b/include/nanorange/algorithm/merge.hpp
@@ -8,12 +8,12 @@
 #define NANORANGE_ALGORITHM_MERGE_HPP_INCLUDED
 
 #include <nanorange/algorithm/copy.hpp>
-#include <nanorange/algorithm/transform.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I1, typename I2, typename O>
-using merge_result = binary_transform_result<I1, I2, O>;
+using merge_result = in_in_out_result<I1, I2, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/minmax.hpp
+++ b/include/nanorange/algorithm/minmax.hpp
@@ -10,29 +10,13 @@
 #ifndef NANORANGE_ALGORITHM_MINMAX_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_MINMAX_HPP_INCLUDED
 
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename T>
-struct minmax_result {
-    NANO_NO_UNIQUE_ADDRESS T min;
-    NANO_NO_UNIQUE_ADDRESS T max;
-
-    template <typename T2,
-              std::enable_if_t<convertible_to<const T&, T2>, int> = 0>
-    constexpr operator minmax_result<T2>() const &
-    {
-        return {min, max};
-    }
-
-    template <typename T2,
-              std::enable_if_t<convertible_to<T, T2>, int> = 0>
-    constexpr operator minmax_result<T2>() &&
-    {
-        return {std::move(min), std::move(max)};
-    }
-};
+using minmax_result = min_max_result<T>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/minmax_element.hpp
+++ b/include/nanorange/algorithm/minmax_element.hpp
@@ -10,12 +10,13 @@
 #ifndef NANORANGE_ALGORITHM_MINMAX_ELEMENT_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_MINMAX_ELEMENT_HPP_INCLUDED
 
-#include <nanorange/algorithm/minmax.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename T>
-using minmax_element_result = minmax_result<T>;
+using minmax_element_result = min_max_result<T>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/mismatch.hpp
+++ b/include/nanorange/algorithm/mismatch.hpp
@@ -7,6 +7,7 @@
 #ifndef NANORANGE_ALGORITHM_MISMATCH_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_MISMATCH_HPP_INCLUDED
 
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
@@ -14,26 +15,7 @@ NANO_BEGIN_NAMESPACE
 // [range.mismatch]
 
 template <typename I1, typename I2>
-struct mismatch_result {
-    NANO_NO_UNIQUE_ADDRESS I1 in1;
-    NANO_NO_UNIQUE_ADDRESS I2 in2;
-
-    template <typename II1, typename II2,
-        std::enable_if_t<convertible_to<const I1&, II1> &&
-                         convertible_to<const I2&, II2>, int> = 0>
-    constexpr operator mismatch_result<II1, II2>() const &
-    {
-        return {in1, in2};
-    }
-
-    template <typename II1, typename II2,
-        std::enable_if_t<convertible_to<I1, II1> &&
-                         convertible_to<I2, II2>, int> = 0>
-    constexpr operator mismatch_result<II1, II2>() &&
-    {
-        return {std::move(in1), std::move(in2)};
-    }
-};
+using mismatch_result = in_in_result<I1, I2>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/move.hpp
+++ b/include/nanorange/algorithm/move.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_MOVE_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_MOVE_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using move_result = copy_result<I, O>;
+using move_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -73,8 +74,8 @@ public:
 
 NANO_INLINE_VAR(detail::move_fn, move)
 
-template <typename I1, typename I2>
-using move_backward_result = copy_result<I1, I2>;
+template <typename I, typename O>
+using move_backward_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/next_permutation.hpp
+++ b/include/nanorange/algorithm/next_permutation.hpp
@@ -21,14 +21,12 @@
 #define NANORANGE_ALGORITHM_NEXT_PERMUTATION_HPP_INCLUDED
 
 #include <nanorange/algorithm/reverse.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I>
-struct next_permutation_result {
-    bool found;
-    I in;
-};
+using next_permutation_result = in_found_result<I>;
 
 namespace detail {
 
@@ -39,14 +37,14 @@ private:
     impl(I first, S last, Comp& comp, Proj& proj)
     {
         if (first == last) {
-            return {false, std::move(first)};
+            return {std::move(first), false};
         }
 
         I last_it = nano::next(first, last);
         I i = last_it;
 
         if (first == --i) {
-            return {false, std::move(last_it)};
+            return {std::move(last_it), false};
         }
 
         while (true) {
@@ -60,12 +58,12 @@ private:
 
                 nano::iter_swap(i, j);
                 nano::reverse(ip1, last_it);
-                return {true, std::move(last_it)};
+                return {std::move(last_it), true};
             }
 
             if (i == first) {
                 nano::reverse(first, last_it);
-                return {false, std::move(last_it)};
+                return {std::move(last_it), false};
             }
         }
     }

--- a/include/nanorange/algorithm/partial_sort_copy.hpp
+++ b/include/nanorange/algorithm/partial_sort_copy.hpp
@@ -7,14 +7,14 @@
 #ifndef NANORANGE_ALGORITHM_PARTIAL_SORT_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_PARTIAL_SORT_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
 #include <nanorange/algorithm/make_heap.hpp>
 #include <nanorange/algorithm/sort_heap.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using partial_sort_copy_result = copy_result<I, O>;
+using partial_sort_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/partition_copy.hpp
+++ b/include/nanorange/algorithm/partition_copy.hpp
@@ -7,34 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_PARTITION_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_PARTITION_COPY_HPP_INCLUDED
 
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O1, typename O2>
-struct partition_copy_result {
-    NANO_NO_UNIQUE_ADDRESS I in;
-    NANO_NO_UNIQUE_ADDRESS O1 out1;
-    NANO_NO_UNIQUE_ADDRESS O2 out2;
-
-    template <typename II, typename OO1, typename OO2,
-              std::enable_if_t<convertible_to<const I&, II> &&
-                               convertible_to<const O1&, OO1> &&
-                               convertible_to<const O2&, OO2>, int> = 0>
-    constexpr operator partition_copy_result<II, OO1, OO2>() const &
-    {
-        return {in, out1, out2};
-    }
-
-    template <typename II, typename OO1, typename OO2,
-        std::enable_if_t<convertible_to<I, II> &&
-                         convertible_to<O1, OO1> &&
-                         convertible_to<O2, OO2>, int> = 0>
-    constexpr operator partition_copy_result<II, OO1, OO2>() &&
-    {
-        return {std::move(in), std::move(out1), std::move(out2)};
-    }
-};
+using partition_copy_result = in_out_out_result<I, O1, O2>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/prev_permutation.hpp
+++ b/include/nanorange/algorithm/prev_permutation.hpp
@@ -20,12 +20,13 @@
 #ifndef NANORANGE_ALGORITHM_PREV_PERMUTATION_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_PREV_PERMUTATION_HPP_INCLUDED
 
-#include <nanorange/algorithm/next_permutation.hpp>
+#include <nanorange/algorithm/reverse.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I>
-using prev_permutation_result = next_permutation_result<I>;
+using prev_permutation_result = in_found_result<I>;
 
 namespace detail {
 
@@ -36,14 +37,14 @@ private:
     impl(I first, S last, Comp& comp, Proj& proj)
     {
         if (first == last) {
-            return {false, std::move(first)};
+            return {std::move(first), false};
         }
 
         I last_it = nano::next(first, last);
         I i = last_it;
 
         if (first == --i) {
-            return {false, std::move(last_it)};
+            return {std::move(last_it), false};
         }
 
         while (true) {
@@ -58,12 +59,12 @@ private:
 
                 nano::iter_swap(i, j);
                 nano::reverse(ip1, last_it);
-                return {true, std::move(last_it)};
+                return {std::move(last_it), true};
             }
 
             if (i == first) {
                 nano::reverse(first, last_it);
-                return {false, std::move(last_it)};
+                return {std::move(last_it), false};
             }
         }
     }

--- a/include/nanorange/algorithm/remove_copy.hpp
+++ b/include/nanorange/algorithm/remove_copy.hpp
@@ -7,13 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_REMOVE_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_REMOVE_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
 #include <nanorange/algorithm/find.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using remove_copy_result = copy_result<I, O>;
+using remove_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/remove_copy_if.hpp
+++ b/include/nanorange/algorithm/remove_copy_if.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_REMOVE_COPY_IF_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_REMOVE_COPY_IF_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using remove_copy_if_result = copy_result<I, O>;
+using remove_copy_if_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/replace_copy.hpp
+++ b/include/nanorange/algorithm/replace_copy.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_REPLACE_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_REPLACE_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using replace_copy_result = copy_result<I, O>;
+using replace_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/replace_copy_if.hpp
+++ b/include/nanorange/algorithm/replace_copy_if.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_REPLACE_COPY_IF_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_REPLACE_COPY_IF_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using replace_copy_if_result = copy_result<I, O>;
+using replace_copy_if_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/reverse_copy.hpp
+++ b/include/nanorange/algorithm/reverse_copy.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_REVERSE_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_REVERSE_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using reverse_copy_result = copy_result<I, O>;
+using reverse_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/rotate_copy.hpp
+++ b/include/nanorange/algorithm/rotate_copy.hpp
@@ -7,13 +7,14 @@
 #ifndef NANORANGE_ALGORITHM_ROTATE_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_ROTATE_COPY_HPP_INCLUDED
 
-#include <nanorange/ranges.hpp>
 #include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using rotate_copy_result = copy_result<I, O>;
+using rotate_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/set_difference.hpp
+++ b/include/nanorange/algorithm/set_difference.hpp
@@ -10,11 +10,12 @@
 #include <nanorange/ranges.hpp>
 
 #include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using set_difference_result = copy_result<I, O>;
+using set_difference_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/set_symmetric_difference.hpp
+++ b/include/nanorange/algorithm/set_symmetric_difference.hpp
@@ -8,12 +8,12 @@
 #define NANORANGE_ALGORITHM_SET_SYMMETRIC_DIFFERENCE_HPP_INCLUDED
 
 #include <nanorange/algorithm/copy.hpp>
-#include <nanorange/algorithm/transform.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I1, typename I2, typename O>
-using set_symmetric_difference_result = binary_transform_result<I1, I2, O>;
+using set_symmetric_difference_result = in_in_out_result<I1, I2, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/set_union.hpp
+++ b/include/nanorange/algorithm/set_union.hpp
@@ -8,12 +8,12 @@
 #define NANORANGE_ALGORITHM_SET_UNION_HPP_INCLUDED
 
 #include <nanorange/algorithm/copy.hpp>
-#include <nanorange/algorithm/transform.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I1, typename I2, typename O>
-using set_union_result = binary_transform_result<I1, I2, O>;
+using set_union_result = in_in_out_result<I1, I2, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/swap_ranges.hpp
+++ b/include/nanorange/algorithm/swap_ranges.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_SWAP_RANGES_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_SWAP_RANGES_HPP_INCLUDED
 
-#include <nanorange/algorithm/mismatch.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I1, typename I2>
-using swap_ranges_result = mismatch_result<I1, I2>;
+using swap_ranges_result = in_in_result<I1, I2>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/transform.hpp
+++ b/include/nanorange/algorithm/transform.hpp
@@ -7,38 +7,16 @@
 #ifndef NANORANGE_ALGORITHM_TRANSFORM_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_TRANSFORM_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using unary_transform_result = copy_result<I, O>;
+using unary_transform_result = in_out_result<I, O>;
 
 template <typename I1, typename I2, typename O>
-struct binary_transform_result {
-    NANO_NO_UNIQUE_ADDRESS I1 in1;
-    NANO_NO_UNIQUE_ADDRESS I2 in2;
-    NANO_NO_UNIQUE_ADDRESS O out;
-
-    template <typename II1, typename II2, typename O2,
-              std::enable_if_t<convertible_to<const I1&, II1> &&
-                               convertible_to<const I2&, II2> &&
-                               convertible_to<const O&, O2>, int> = 0>
-    constexpr operator binary_transform_result<II1, II2, O2>() const &
-    {
-        return {in1, in2, out};
-    }
-
-    template <typename II1, typename II2, typename O2,
-              std::enable_if_t<convertible_to<I1, II1> &&
-                               convertible_to<I2, II2> &&
-                               convertible_to<O, O2>, int> = 0>
-    constexpr operator binary_transform_result<II1, II2, O2>() &&
-    {
-        return {std::move(in1), std::move(in2), std::move(out)};
-    }
-};
-
+using binary_transform_result  = in_in_out_result<I1, I2, O>;
 
 namespace detail {
 

--- a/include/nanorange/algorithm/unique_copy.hpp
+++ b/include/nanorange/algorithm/unique_copy.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_ALGORITHM_UNIQUE_COPY_HPP_INCLUDED
 #define NANORANGE_ALGORITHM_UNIQUE_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/ranges.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using unique_copy_result = copy_result<I, O>;
+using unique_copy_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/detail/algorithm/result_types.hpp
+++ b/include/nanorange/detail/algorithm/result_types.hpp
@@ -1,0 +1,172 @@
+// nanorange/detail/algorithm/result_types.hpp
+//
+// Copyright (c) 2020 Boris Staletic (boris dot staletic at gmail dot com)
+// Copyright (c) 2020 Tristan Brindle (tcbrindle at gmail dot com)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef NANORANGE_DETAIL_ALGORITHM_RETURN_TYPES
+#define NANORANGE_DETAIL_ALGORITHM_RETURN_TYPES
+
+#include <nanorange/detail/macros.hpp>
+#include <nanorange/detail/concepts/core.hpp>
+
+#include <type_traits>
+
+NANO_BEGIN_NAMESPACE
+
+template <typename I, typename F>
+struct in_fun_result {
+    NANO_NO_UNIQUE_ADDRESS I in;
+    NANO_NO_UNIQUE_ADDRESS F fun;
+
+    template <typename I2, typename F2,
+              std::enable_if_t<convertible_to<const I&, I2> &&
+                               convertible_to<const F&, F2>, int> = 0>
+    constexpr operator in_fun_result<I2, F2>() const &
+    {
+        return {in, fun};
+    }
+
+    template <typename I2, typename F2,
+        std::enable_if_t<convertible_to<I, I2> &&
+                         convertible_to<F, F2>, int> = 0>
+    constexpr operator in_fun_result<I2, F2>() &&
+    {
+        return {std::move(in), std::move(fun)};
+    }
+};
+
+template <typename I1, typename I2>
+struct in_in_result {
+    NANO_NO_UNIQUE_ADDRESS I1 in1;
+    NANO_NO_UNIQUE_ADDRESS I2 in2;
+
+    template <typename II1, typename II2,
+        std::enable_if_t<convertible_to<const I1&, II1> &&
+                         convertible_to<const I2&, II2>, int> = 0>
+    constexpr operator in_in_result<II1, II2>() const &
+    {
+        return {in1, in2};
+    }
+
+    template <typename II1, typename II2,
+        std::enable_if_t<convertible_to<I1, II1> &&
+                         convertible_to<I2, II2>, int> = 0>
+    constexpr operator in_in_result<II1, II2>() &&
+    {
+        return {std::move(in1), std::move(in2)};
+    }
+};
+
+template <typename I, typename O>
+struct in_out_result {
+    NANO_NO_UNIQUE_ADDRESS I in;
+    NANO_NO_UNIQUE_ADDRESS O out;
+
+    template <typename I2, typename O2,
+              std::enable_if_t<convertible_to<const I&, I2> &&
+                               convertible_to<const O&, O2>, int> = 0>
+    constexpr operator in_out_result<I2, O2>() const &
+    {
+        return {in, out};
+    }
+
+    template <typename I2, typename O2,
+              std::enable_if_t<convertible_to<I, I2> &&
+                               convertible_to<O, O2>, int> = 0>
+    constexpr operator in_out_result<I2, O2>() &&
+    {
+        return {std::move(in), std::move(out)};
+    }
+};
+
+template <typename I1, typename I2, typename O>
+struct in_in_out_result {
+    NANO_NO_UNIQUE_ADDRESS I1 in1;
+    NANO_NO_UNIQUE_ADDRESS I2 in2;
+    NANO_NO_UNIQUE_ADDRESS O out;
+
+    template <typename II1, typename II2, typename O2,
+              std::enable_if_t<convertible_to<const I1&, II1> &&
+                               convertible_to<const I2&, II2> &&
+                               convertible_to<const O&, O2>, int> = 0>
+    constexpr operator in_in_out_result<II1, II2, O2>() const &
+    {
+        return {in1, in2, out};
+    }
+
+    template <typename II1, typename II2, typename O2,
+              std::enable_if_t<convertible_to<I1, II1> &&
+                               convertible_to<I2, II2> &&
+                               convertible_to<O, O2>, int> = 0>
+    constexpr operator in_in_out_result<II1, II2, O2>() &&
+    {
+        return {std::move(in1), std::move(in2), std::move(out)};
+    }
+};
+
+template <typename I, typename O1, typename O2>
+struct in_out_out_result {
+    NANO_NO_UNIQUE_ADDRESS I in;
+    NANO_NO_UNIQUE_ADDRESS O1 out1;
+    NANO_NO_UNIQUE_ADDRESS O2 out2;
+
+    template <typename II, typename OO1, typename OO2,
+              std::enable_if_t<convertible_to<const I&, II> &&
+                               convertible_to<const O1&, OO1> &&
+                               convertible_to<const O2&, OO2>, int> = 0>
+    constexpr operator in_out_out_result<II, OO1, OO2>() const &
+    {
+        return {in, out1, out2};
+    }
+
+    template <typename II, typename OO1, typename OO2,
+        std::enable_if_t<convertible_to<I, II> &&
+                         convertible_to<O1, OO1> &&
+                         convertible_to<O2, OO2>, int> = 0>
+    constexpr operator in_out_out_result<II, OO1, OO2>() &&
+    {
+        return {std::move(in), std::move(out1), std::move(out2)};
+    }
+};
+
+template <typename T>
+struct min_max_result {
+    NANO_NO_UNIQUE_ADDRESS T min;
+    NANO_NO_UNIQUE_ADDRESS T max;
+
+    template <typename T2,
+              std::enable_if_t<convertible_to<const T&, T2>, int> = 0>
+    constexpr operator min_max_result<T2>() const &
+    {
+        return {min, max};
+    }
+
+    template <typename T2,
+              std::enable_if_t<convertible_to<T, T2>, int> = 0>
+    constexpr operator min_max_result<T2>() &&
+    {
+        return {std::move(min), std::move(max)};
+    }
+};
+
+template <typename I>
+struct in_found_result {
+    NANO_NO_UNIQUE_ADDRESS I in;
+    bool found;
+    template<class I2,
+             std::enable_if_t< convertible_to<const I&, I2>, int> = 0>
+    constexpr operator in_found_result<I2>() const & {
+      return {in, found};
+    }
+    template<class I2,
+             std::enable_if_t< convertible_to<const I&, I2>, int> = 0>
+    constexpr operator in_found_result<I2>() && {
+      return {std::move(in), found};
+    }
+};
+
+NANO_END_NAMESPACE
+
+#endif

--- a/include/nanorange/detail/iterator/projected.hpp
+++ b/include/nanorange/detail/iterator/projected.hpp
@@ -7,6 +7,7 @@
 #ifndef NANORANGE_DETAIL_ITERATOR_PROJECTED_HPP_INCLUDED
 #define NANORANGE_DETAIL_ITERATOR_PROJECTED_HPP_INCLUDED
 
+#include <nanorange/detail/functional/identity.hpp>
 #include <nanorange/detail/iterator/indirect_callable_concepts.hpp>
 
 NANO_BEGIN_NAMESPACE

--- a/include/nanorange/memory/uninitialized_copy.hpp
+++ b/include/nanorange/memory/uninitialized_copy.hpp
@@ -7,13 +7,13 @@
 #ifndef NANORANGE_MEMORY_UNINITIALIZED_COPY_HPP_INCLUDED
 #define NANORANGE_MEMORY_UNINITIALIZED_COPY_HPP_INCLUDED
 
-#include <nanorange/algorithm/copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
 #include <nanorange/memory/destroy.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using uninitialized_copy_result = copy_result<I, O>;
+using uninitialized_copy_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -120,7 +120,7 @@ public:
 NANO_INLINE_VAR(detail::uninitialized_copy_fn, uninitialized_copy)
 
 template <typename I, typename O>
-using uninitialized_copy_n_result = uninitialized_copy_result<I, O>;
+using uninitialized_copy_n_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/include/nanorange/memory/uninitialized_move.hpp
+++ b/include/nanorange/memory/uninitialized_move.hpp
@@ -7,12 +7,13 @@
 #ifndef NANORANGE_MEMORY_UNINITIALIZED_MOVE_HPP_INCLUDED
 #define NANORANGE_MEMORY_UNINITIALIZED_MOVE_HPP_INCLUDED
 
-#include <nanorange/memory/uninitialized_copy.hpp>
+#include <nanorange/detail/algorithm/result_types.hpp>
+#include <nanorange/memory/destroy.hpp>
 
 NANO_BEGIN_NAMESPACE
 
 template <typename I, typename O>
-using uninitialized_move_result = uninitialized_copy_result<I, O>;
+using uninitialized_move_result = in_out_result<I, O>;
 
 namespace detail {
 
@@ -118,7 +119,7 @@ public:
 NANO_INLINE_VAR(detail::uninitialized_move_fn, uninitialized_move)
 
 template <typename I, typename O>
-using uninitialized_move_n_result = uninitialized_copy_result<I, O>;
+using uninitialized_move_n_result = in_out_result<I, O>;
 
 namespace detail {
 

--- a/test/algorithm/minmax_element.cpp
+++ b/test/algorithm/minmax_element.cpp
@@ -37,7 +37,7 @@ template <class Iter, class Sent = Iter>
 void
 test_iter(Iter first, Sent last)
 {
-	stl2::minmax_result<Iter> p = stl2::minmax_element(first, last);
+	stl2::minmax_element_result<Iter> p = stl2::minmax_element(first, last);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j) {
 			CHECK(!(*j < *p.min));
@@ -100,7 +100,7 @@ test_iter()
 		std::unique_ptr<int[]> a{new int[N]};
 		std::fill_n(a.get(), N, 5);
 		std::shuffle(a.get(), a.get() + N, gen);
-		stl2::minmax_result<Iter> p = stl2::minmax_element(Iter(a.get()),
+		stl2::minmax_element_result<Iter> p = stl2::minmax_element(Iter(a.get()),
 													   Sent(a.get() + N));
 		CHECK(base(p.min) == a.get());
 		CHECK(base(p.max) == a.get() + N - 1);
@@ -113,7 +113,7 @@ test_iter_comp(Iter first, Sent last)
 {
 	typedef std::greater<int> Compare;
 	Compare comp;
-	stl2::minmax_result<Iter> p = stl2::minmax_element(first, last, comp);
+	stl2::minmax_element_result<Iter> p = stl2::minmax_element(first, last, comp);
 	if (first != last) {
 		for (Iter j = first; j != last; ++j) {
 			CHECK(!comp(*j, *p.min));
@@ -178,7 +178,7 @@ test_iter_comp()
 		std::shuffle(a.get(), a.get() + N, gen);
 		typedef std::greater<int> Compare;
 		Compare comp;
-		stl2::minmax_result<Iter> p = stl2::minmax_element(Iter(a.get()),
+		stl2::minmax_element_result<Iter> p = stl2::minmax_element(Iter(a.get()),
 													   Sent(a.get() + N), comp);
 		CHECK(base(p.min) == a.get());
 		CHECK(base(p.max) == a.get() + N - 1);
@@ -211,7 +211,7 @@ TEST_CASE("alg.minmax_element")
 
 	// Works with projections?
 	S const s[] = {S{1},S{2},S{3},S{4},S{-4},S{5},S{6},S{40},S{7},S{8},S{9}};
-	stl2::minmax_result<S const *> ps = stl2::minmax_element(s, std::less<int>{}, &S::i);
+	stl2::minmax_element_result<S const *> ps = stl2::minmax_element(s, std::less<int>{}, &S::i);
 	CHECK(ps.min->i == -4);
 	CHECK(ps.max->i == 40);
 }


### PR DESCRIPTION
Apart from changing every return type to be an alias of something in `<nanorange/detail/algorithm/return_types.hpp>`, there are some other notable changes in this pull request:

- Headers that did not include `<nanorange/ranges.hpp>` after replacing `<nanorange/algorithm/other_algorithm.hpp>` with the `return_types.hpp`, needed additional includes, so I included more stuff from `detail`. This is the case with `minmax_element.hpp` for example.
- `next_permutation_result` used to be `{ bool, It }`, while the standard specifies `in_found_result` as `{ [[no_unique_address]] It, bool }`.

Reference: https://eel.is/c++draft/algorithms.results