### PR TITLE
Update constructors of views according to the latest C++ draft

### DIFF
--- a/include/nanorange/views/empty.hpp
+++ b/include/nanorange/views/empty.hpp
@@ -24,9 +24,6 @@ public:
     static constexpr T* data() noexcept { return nullptr; }
 
     static constexpr bool empty() noexcept { return true; }
-
-    friend constexpr T* begin(empty_view) noexcept { return nullptr; }
-    friend constexpr T* end(empty_view) noexcept { return nullptr; }
 };
 
 }

--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -213,13 +213,6 @@ public:
         : base_(std::move(base)), pred_(std::move(pred))
     {}
 
-    template <typename R,
-              std::enable_if_t<input_range<R> && constructible_from<V, all_view<R>>,
-                               int> = 0>
-    constexpr filter_view(R&& r, Pred pred)
-        : base_(views::all(std::forward<R>(r))), pred_(std::move(pred))
-    {}
-
     constexpr V base() const { return base_; }
 
     constexpr iterator begin()

--- a/include/nanorange/views/iota.hpp
+++ b/include/nanorange/views/iota.hpp
@@ -303,6 +303,9 @@ public:
           bound_(bound)
     {}
 
+    constexpr iota_view(iterator first, sentinel last)
+        : iota_view(*first, last.bound_) {}
+
     constexpr iterator begin() const
     {
         return iterator{value_};

--- a/include/nanorange/views/join.hpp
+++ b/include/nanorange/views/join.hpp
@@ -300,15 +300,6 @@ public:
         : data_{std::move(base)}
     {}
 
-    template <typename R,
-              std::enable_if_t<detail::not_same_as<R, join_view>, int> = 0,
-              std::enable_if_t<input_range<R>, int> = 0,
-              std::enable_if_t<viewable_range<R>, int> = 0,
-              std::enable_if_t<constructible_from<V, all_view<R>>, int> = 0>
-    constexpr join_view(R&& r)
-        : data_{views::all(std::forward<R>(r))}
-    {}
-
     constexpr auto begin()
     {
         return iterator<detail::simple_view<V>>{*this, ranges::begin(data_.base_)};

--- a/include/nanorange/views/reverse.hpp
+++ b/include/nanorange/views/reverse.hpp
@@ -40,19 +40,6 @@ struct reverse_view
         : base_(std::move(r))
     {}
 
-    template <typename R,
-              /* FIXME: This is not to spec, but we get in horrible recursive trouble if it's omitted */
-              std::enable_if_t<detail::not_same_as<R, reverse_view>, int> = 0,
-              std::enable_if_t<viewable_range<R> && bidirectional_range<R> &&
-                  constructible_from<V, all_view<R>>, int> = 0>
-    constexpr explicit reverse_view(R&& r)
-        : base_(views::all(std::forward<R>(r)))
-    {}
-
-    constexpr reverse_view(const reverse_view& other)
-        : base_(other.base_)
-    {}
-
     constexpr V base() const { return base_; }
 
     constexpr reverse_iterator<iterator_t<V>> begin()

--- a/include/nanorange/views/split.hpp
+++ b/include/nanorange/views/split.hpp
@@ -364,14 +364,6 @@ public:
         : data_{std::move(base), std::move(pattern)}
     {}
 
-    template <typename R, typename P,
-              std::enable_if_t<constructible_from<V, all_view<R>>, int> = 0,
-              std::enable_if_t<constructible_from<Pattern, all_view<P>>, int> = 0,
-              std::enable_if_t<input_range<R> && forward_range<P>, int> = 0>
-    constexpr split_view(R&& r, P&& p)
-        : data_{views::all(std::forward<R>(r)) , views::all(std::forward<P>(p))}
-    {}
-
     template <typename R,
               std::enable_if_t<constructible_from<V, all_view<R>>, int> = 0,
               std::enable_if_t<

--- a/include/nanorange/views/take.hpp
+++ b/include/nanorange/views/take.hpp
@@ -80,13 +80,6 @@ public:
           count_(count)
     {}
 
-    template <typename R, std::enable_if_t<
-        viewable_range<R> && constructible_from<V, all_view<R>>, int> = 0>
-    constexpr take_view(R&& r, range_difference_t<V> count)
-        : base_(views::all(std::forward<R>(r))),
-          count_(count)
-    {}
-
     constexpr V base() const { return base_; }
 
     template <typename VV = V, std::enable_if_t<!detail::simple_view<VV>, int> = 0>

--- a/include/nanorange/views/transform.hpp
+++ b/include/nanorange/views/transform.hpp
@@ -301,15 +301,6 @@ public:
           fun_(std::move(fun))
     {}
 
-    template <typename R, std::enable_if_t<
-        input_range<R> &&
-        viewable_range<R> &&
-        constructible_from<V, all_view<R>>, int> = 0>
-    constexpr transform_view(R&& r, F fun)
-        : base_(views::all(std::forward<R>(r))),
-          fun_(std::move(fun))
-    {}
-
     constexpr V base() const { return base_; }
 
     constexpr iterator<false> begin()


### PR DESCRIPTION
Should take NanoRange another step closer to matching the C++20 standard. For `filter`, `join`, `reverse`, `split`, `take` and `transform`, this is just a simple removal of converting constructors, while `empty`, `iota` and `subrange` deserve more attention.  Details will be in the review comments.