### PR TITLE
Precompile catch.hpp to try to speed up CI builds

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 
+add_library(catch_main catch_main.cpp)
+target_compile_features(catch_main PUBLIC cxx_std_17)
+
 add_executable(test_nanorange
-    catch_main.cpp
     test_concepts.cpp
     #test_type_traits.cpp
 
@@ -194,7 +196,12 @@ add_executable(test_nanorange
     views/transform_view.cpp
 )
 target_compile_definitions(test_nanorange PRIVATE "-DNANORANGE_NO_DEPRECATION_WARNINGS")
-target_link_libraries(test_nanorange PRIVATE nanorange)
+target_link_libraries(test_nanorange PRIVATE nanorange catch_main)
+
+# Precompile catch.hpp if we have a new enough CMake
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+    target_precompile_headers(test_nanorange PRIVATE "catch.hpp")
+endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(test_nanorange PRIVATE -Wall -Wextra -pedantic


### PR DESCRIPTION
CMake 3.16 has built-in support for precompiled headers. Since catch.hpp is very large, and is included in almost every TU in the test suite, we might be able to get a speedup in CI times by precompiling it.