### PR TITLE
Fix copy&paste error in front_insert_iterator

### DIFF
--- a/include/nanorange/iterator/front_insert_iterator.hpp
+++ b/include/nanorange/iterator/front_insert_iterator.hpp
@@ -30,7 +30,7 @@ struct front_insert_iterator {
 
     front_insert_iterator& operator=(iter_value_t<Container>&& value)
     {
-        cont_->front_back(std::move(value));
+        cont_->push_front(std::move(value));
         return *this;
     }
 

--- a/single_include/nanorange.hpp
+++ b/single_include/nanorange.hpp
@@ -14270,7 +14270,7 @@ struct front_insert_iterator {
 
     front_insert_iterator& operator=(iter_value_t<Container>&& value)
     {
-        cont_->front_back(std::move(value));
+        cont_->push_front(std::move(value));
         return *this;
     }
 

--- a/single_include/nanorange.hpp
+++ b/single_include/nanorange.hpp
@@ -14270,7 +14270,7 @@ struct front_insert_iterator {
 
     front_insert_iterator& operator=(iter_value_t<Container>&& value)
     {
-        cont_->push_front(std::move(value));
+        cont_->front_back(std::move(value));
         return *this;
     }
 


### PR DESCRIPTION
The second `operator=` calls `cont_->front_back`
but I think that's a typo and it should call `cont_->push_front`
like the first `operator=` does.