### PR TITLE
Implement ranges::cdata

### DIFF
--- a/include/nanorange/detail/ranges/primitives.hpp
+++ b/include/nanorange/detail/ranges/primitives.hpp
@@ -226,6 +226,44 @@ public:
 
 NANO_INLINE_VAR(detail::data_::fn, data)
 
+namespace detail {
+namespace cdata_ {
+
+struct fn {
+private:
+    template <typename T, typename U = std::remove_reference_t<T>,
+	      std::enable_if_t<std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::data(static_cast<const U&>(t))))
+	-> decltype(ranges::data(static_cast<const U&>(t)))
+    {
+	return ranges::data(static_cast<const U&>(t));
+    }
+
+    template <typename T,
+	      std::enable_if_t<!std::is_lvalue_reference_v<T>, int> = 0>
+    static constexpr auto impl(T&& t)
+        noexcept(noexcept(ranges::data(static_cast<const T&&>(t))))
+	-> decltype(ranges::data(static_cast<const T&&>(t)))
+    {
+	return ranges::data(static_cast<const T&&>(t));
+    }
+
+public:
+    template <typename T>
+    constexpr auto operator()(T&& t) const
+        noexcept(noexcept(fn::impl(std::forward<T>(t))))
+	-> decltype(fn::impl(std::forward<T>(t)))
+    {
+	return fn::impl(std::forward<T>(t));
+    }
+};
+
+} // namespace cdata_
+} // namespace detail
+
+NANO_INLINE_VAR(detail::cdata_::fn, cdata)
+
 NANO_END_NAMESPACE
 
 #endif

--- a/test/range_access.cpp
+++ b/test/range_access.cpp
@@ -56,6 +56,7 @@ void test_initializer_list()
     CHECK(ranges::size(il) == std::size_t{3});
     CHECK(ranges::ssize(il) == std::ptrdiff_t{3});
     CHECK(ranges::data(il) == &*il.begin());
+    CHECK(ranges::cdata(il) == &*il.begin());
     CHECK(ranges::empty(il) == false);
 }
 
@@ -78,6 +79,7 @@ void test_array(std::index_sequence<Is...>)
     CHECK(ranges::size(a) == sizeof...(Is));
     CHECK(ranges::ssize(a) == sizeof...(Is));
     CHECK(ranges::data(a) == a + 0);
+    CHECK(ranges::cdata(a) == a + 0);
     CHECK(ranges::empty(a) == false);
 }
 
@@ -347,6 +349,7 @@ TEST_CASE("range_access") {
 		static_assert(noexcept(cend(not_a_constant_expression)));
 		static_assert(noexcept(empty(not_a_constant_expression)));
 		static_assert(noexcept(data(not_a_constant_expression)));
+		static_assert(noexcept(cdata(not_a_constant_expression)));
 	}
 
 	constexpr bool output = false;


### PR DESCRIPTION
Reference: https://eel.is/c++draft/range.access#range.prim.cdata

Basically `cdata` is to `data` what `cbegin` is to `begin` - add const and call the other one.