### PR TITLE
Add [[nodiscard]] to algorithms and views

### DIFF
--- a/include/nanorange/algorithm/adjacent_find.hpp
+++ b/include/nanorange/algorithm/adjacent_find.hpp
@@ -44,7 +44,7 @@ private:
 public:
     template <typename I, typename S, typename Proj = identity,
               typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
+    [[nodiscard]] constexpr std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
                                    indirect_relation<Pred, projected<I, Proj>>,
                                I>
     operator()(I first, S last, Pred pred = Pred{}, Proj proj = Proj{}) const
@@ -55,7 +55,7 @@ public:
 
     template <typename Rng, typename Proj = identity,
               typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_relation<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/all_of.hpp
+++ b/include/nanorange/algorithm/all_of.hpp
@@ -31,7 +31,7 @@ private:
 
 public:
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         bool>
@@ -42,7 +42,7 @@ public:
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         bool>

--- a/include/nanorange/algorithm/any_of.hpp
+++ b/include/nanorange/algorithm/any_of.hpp
@@ -34,7 +34,7 @@ private:
 
 public:
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         bool>
@@ -45,7 +45,7 @@ public:
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         bool>

--- a/include/nanorange/algorithm/binary_search.hpp
+++ b/include/nanorange/algorithm/binary_search.hpp
@@ -26,7 +26,7 @@ private:
 public:
     template <typename I, typename S, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>,
     bool>
@@ -39,7 +39,7 @@ public:
 
     template <typename Rng, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<forward_range<Rng> &&
+    [[nodiscard]] std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
     bool>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},

--- a/include/nanorange/algorithm/clamp.hpp
+++ b/include/nanorange/algorithm/clamp.hpp
@@ -15,7 +15,7 @@ namespace detail {
 
 struct clamp_fn {
     template <typename T, typename Proj = identity, typename Comp = nano::less>
-    constexpr std::enable_if_t<indirect_strict_weak_order<Comp, projected<const T*, Proj>>, const T&>
+    [[nodiscard]] constexpr std::enable_if_t<indirect_strict_weak_order<Comp, projected<const T*, Proj>>, const T&>
     operator()(const T& value, const T& low, const T& high, Comp comp = {}, Proj proj = Proj{}) const
     {
         auto&& projected_value = nano::invoke(proj, value);

--- a/include/nanorange/algorithm/count.hpp
+++ b/include/nanorange/algorithm/count.hpp
@@ -37,7 +37,7 @@ private:
 
 public:
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         iter_difference_t<I>>
@@ -48,7 +48,7 @@ public:
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         range_difference_t<Rng>>
@@ -66,7 +66,7 @@ namespace detail {
 
 struct count_fn {
     template <typename I, typename S, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_relation<ranges::equal_to, projected<I, Proj>, const T*>,
         iter_difference_t<I>>
@@ -78,7 +78,7 @@ struct count_fn {
     }
 
     template <typename Rng, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,

--- a/include/nanorange/algorithm/equal.hpp
+++ b/include/nanorange/algorithm/equal.hpp
@@ -55,7 +55,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Pred = ranges::equal_to, typename Proj1 = identity,
               typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && input_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirectly_comparable<I1, I2, Pred, Proj1, Proj2> &&
@@ -79,7 +79,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Pred = ranges::equal_to, typename Proj1 = identity,
               typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && input_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirectly_comparable<I1, I2, Pred, Proj1, Proj2> &&
@@ -112,7 +112,7 @@ public:
     // Two ranges, both sized
     template <typename Rng1, typename Rng2, typename Pred = ranges::equal_to,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && input_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred,
                                  Proj1, Proj2> &&
@@ -132,7 +132,7 @@ public:
     // Two ranges, not both sized
     template <typename Rng1, typename Rng2, typename Pred = ranges::equal_to,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && input_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred,
                                  Proj1, Proj2> &&

--- a/include/nanorange/algorithm/equal_range.hpp
+++ b/include/nanorange/algorithm/equal_range.hpp
@@ -28,7 +28,7 @@ private:
 public:
     template <typename I, typename S, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>,
     subrange<I>>
@@ -41,7 +41,7 @@ public:
 
     template <typename Rng, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<forward_range<Rng> &&
+    [[nodiscard]] std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
                      borrowed_subrange_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},

--- a/include/nanorange/algorithm/find.hpp
+++ b/include/nanorange/algorithm/find.hpp
@@ -34,7 +34,7 @@ private:
 
 public:
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         I>
@@ -44,7 +44,7 @@ public:
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>
@@ -61,7 +61,7 @@ namespace detail {
 
 struct find_fn {
     template <typename I, typename S, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_relation<ranges::equal_to, projected<I, Proj>, const T*>,
         I>
@@ -72,7 +72,7 @@ struct find_fn {
     }
 
     template <typename Rng, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,
@@ -104,7 +104,7 @@ private:
 
 public:
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         I>
@@ -116,7 +116,7 @@ public:
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/find_end.hpp
+++ b/include/nanorange/algorithm/find_end.hpp
@@ -50,7 +50,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
             typename Pred = ranges::equal_to, typename Proj1 = identity,
             typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I1> && sentinel_for<S1, I1> && forward_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirectly_comparable<I1, I2, Pred, Proj1, Proj2>,
@@ -65,7 +65,7 @@ public:
 
     template <typename Rng1, typename Rng2, typename Pred = ranges::equal_to,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng1> && forward_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred, Proj1, Proj2>,
         borrowed_subrange_t<Rng1>>

--- a/include/nanorange/algorithm/find_first_of.hpp
+++ b/include/nanorange/algorithm/find_first_of.hpp
@@ -38,7 +38,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Proj1 = identity, typename Proj2 = identity,
               typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && forward_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirect_relation<Pred, projected<I1, Proj1>, projected<I2, Proj2>>,
@@ -53,7 +53,7 @@ public:
 
     template <typename Rng1, typename Rng2, typename Proj1 = identity,
               typename Proj2 = identity, typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && forward_range<Rng2> &&
             indirect_relation<Pred, projected<iterator_t<Rng1>, Proj1>,
                              projected<iterator_t<Rng2>, Proj2>>,

--- a/include/nanorange/algorithm/includes.hpp
+++ b/include/nanorange/algorithm/includes.hpp
@@ -51,7 +51,7 @@ private:
 public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Comp = ranges::less, typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && input_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirect_strict_weak_order<Comp, projected<I1, Proj1>, projected<I2, Proj2>>,
@@ -66,7 +66,7 @@ public:
 
     template <typename Rng1, typename Rng2, typename Comp = ranges::less,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && input_range<Rng2> &&
             indirect_strict_weak_order<Comp,
                                 projected<iterator_t<Rng1>, Proj1>,

--- a/include/nanorange/algorithm/is_heap.hpp
+++ b/include/nanorange/algorithm/is_heap.hpp
@@ -16,7 +16,7 @@ namespace detail {
 struct is_heap_fn {
     template <typename I, typename S, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<random_access_iterator<I> && sentinel_for<S, I> &&
+    [[nodiscard]] std::enable_if_t<random_access_iterator<I> && sentinel_for<S, I> &&
                          indirect_strict_weak_order<Comp, projected<I, Proj>>,
                      bool>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -26,7 +26,7 @@ struct is_heap_fn {
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         random_access_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         bool>

--- a/include/nanorange/algorithm/is_heap_until.hpp
+++ b/include/nanorange/algorithm/is_heap_until.hpp
@@ -58,7 +58,7 @@ private:
 public:
     template <typename I, typename S, typename Comp = ranges::less,
               typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         random_access_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>,
         I>
@@ -69,7 +69,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         random_access_range<Rng> &&
         indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/is_partitioned.hpp
+++ b/include/nanorange/algorithm/is_partitioned.hpp
@@ -24,7 +24,7 @@ private:
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>, bool>
     operator()(I first, S last, Pred pred = Pred{}, Proj proj = Proj{}) const
@@ -34,7 +34,7 @@ public:
     }
 
     template <typename Rng, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>, bool>
     operator()(Rng&& rng, Pred pred = Pred{}, Proj proj = Proj{}) const

--- a/include/nanorange/algorithm/is_permutation.hpp
+++ b/include/nanorange/algorithm/is_permutation.hpp
@@ -114,7 +114,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Pred = ranges::equal_to, typename Proj1 = identity,
               typename Proj2 = identity>
-    constexpr
+    [[nodiscard]] constexpr
         std::enable_if_t<
         forward_iterator<I1> && sentinel_for<S1, I1> && forward_iterator<I2> &&
             sentinel_for<S2, I2> &&
@@ -160,7 +160,7 @@ public:
     // Two ranges
     template <typename Rng1, typename Rng2, typename Pred = ranges::equal_to,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng1> && forward_range<Rng2> &&
             indirectly_comparable<iterator_t<Rng1>, iterator_t<Rng2>, Pred,
                                  Proj1, Proj2>,

--- a/include/nanorange/algorithm/is_sorted.hpp
+++ b/include/nanorange/algorithm/is_sorted.hpp
@@ -16,7 +16,7 @@ namespace detail {
 struct is_sorted_fn {
     template <typename I, typename S, typename Comp = ranges::less,
             typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>, bool>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -26,7 +26,7 @@ struct is_sorted_fn {
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         bool>

--- a/include/nanorange/algorithm/is_sorted_until.hpp
+++ b/include/nanorange/algorithm/is_sorted_until.hpp
@@ -41,7 +41,7 @@ private:
 public:
     template <typename I, typename S, typename Comp = ranges::less,
               typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>, I>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -51,7 +51,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/lexicographical_compare.hpp
+++ b/include/nanorange/algorithm/lexicographical_compare.hpp
@@ -39,7 +39,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Comp = ranges::less, typename Proj1 = identity,
               typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && input_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirect_strict_weak_order<Comp, projected<I1, Proj1>, projected<I2, Proj2>>,
@@ -55,7 +55,7 @@ public:
 
     template <typename Rng1, typename Rng2, typename Comp = ranges::less,
               typename Proj1 = identity, typename Proj2 = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && input_range<Rng2> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng1>, Proj1>,
                                       projected<iterator_t<Rng2>, Proj2>>,

--- a/include/nanorange/algorithm/lower_bound.hpp
+++ b/include/nanorange/algorithm/lower_bound.hpp
@@ -42,7 +42,7 @@ private:
 public:
     template <typename I, typename S, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>,
         I>
@@ -55,7 +55,7 @@ public:
 
     template <typename Rng, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<forward_range<Rng> &&
+    [[nodiscard]] std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
                      borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},

--- a/include/nanorange/algorithm/max.hpp
+++ b/include/nanorange/algorithm/max.hpp
@@ -38,7 +38,7 @@ private:
 
 public:
     template <typename T, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         indirect_strict_weak_order<Comp, projected<const T*, Proj>>,
     const T&>
     operator()(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -49,7 +49,7 @@ public:
     }
 
     template <typename T, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         copyable<T> &&
             indirect_strict_weak_order<Comp, projected<const T*, Proj>>,
             T>
@@ -60,7 +60,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> && copyable<iter_value_t<iterator_t<Rng>>> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
     range_value_t<Rng>>

--- a/include/nanorange/algorithm/max_element.hpp
+++ b/include/nanorange/algorithm/max_element.hpp
@@ -36,7 +36,7 @@ struct max_element_fn {
 public:
     template <typename I, typename S, typename Comp = ranges::less,
             typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>, I>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -46,7 +46,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/min.hpp
+++ b/include/nanorange/algorithm/min.hpp
@@ -38,7 +38,7 @@ private:
 
 public:
     template <typename T, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         indirect_strict_weak_order<Comp, projected<const T*, Proj>>,
         const T&>
     operator()(const T& a, const T& b, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -48,7 +48,7 @@ public:
     }
 
     template <typename T, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         copyable<T> &&
             indirect_strict_weak_order<Comp, projected<const T*, Proj>>,
         T>
@@ -59,7 +59,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> && copyable<iter_value_t<iterator_t<Rng>>> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         range_value_t<Rng>>

--- a/include/nanorange/algorithm/min_element.hpp
+++ b/include/nanorange/algorithm/min_element.hpp
@@ -39,7 +39,7 @@ private:
 public:
     template <typename I, typename S, typename Comp = ranges::less,
               typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, projected<I, Proj>>, I>
     operator()(I first, S last, Comp comp = Comp{}, Proj proj = Proj{}) const
@@ -49,7 +49,7 @@ public:
     }
 
     template <typename Rng, typename Comp = ranges::less, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_strict_weak_order<Comp, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/mismatch.hpp
+++ b/include/nanorange/algorithm/mismatch.hpp
@@ -93,7 +93,7 @@ public:
     template <typename I1, typename S1, typename I2, typename S2,
               typename Proj1 = identity, typename Proj2 = identity,
               typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I1> && sentinel_for<S1, I1> && input_iterator<I2> &&
             sentinel_for<S2, I2> &&
             indirect_relation<Pred, projected<I1, Proj1>, projected<I2, Proj2>>,
@@ -109,7 +109,7 @@ public:
     // two ranges
     template <typename Rng1, typename Rng2, typename Proj1 = identity,
               typename Proj2 = identity, typename Pred = ranges::equal_to>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng1> && input_range<Rng2> &&
             indirect_relation<Pred, projected<iterator_t<Rng1>, Proj1>,
                              projected<iterator_t<Rng2>, Proj2>>,

--- a/include/nanorange/algorithm/none_of.hpp
+++ b/include/nanorange/algorithm/none_of.hpp
@@ -18,7 +18,7 @@ namespace detail {
 struct none_of_fn {
 
     template <typename I, typename S, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         bool>
@@ -28,7 +28,7 @@ struct none_of_fn {
     }
 
     template <typename Rng, typename Proj = identity, typename Pred>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         input_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         bool>

--- a/include/nanorange/algorithm/partition.hpp
+++ b/include/nanorange/algorithm/partition.hpp
@@ -40,7 +40,7 @@ private:
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>, subrange<I>>
     operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
@@ -50,7 +50,7 @@ public:
     }
 
     template <typename Rng, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_subrange_t<Rng>>

--- a/include/nanorange/algorithm/partition_point.hpp
+++ b/include/nanorange/algorithm/partition_point.hpp
@@ -85,7 +85,7 @@ private:
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
-    std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
+    [[nodiscard]] std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
                          indirect_unary_predicate<Pred, projected<I, Proj>>, I>
     constexpr operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
     {
@@ -94,7 +94,7 @@ public:
     }
 
     template <typename Rng, typename Pred, typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         forward_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/remove.hpp
+++ b/include/nanorange/algorithm/remove.hpp
@@ -38,7 +38,7 @@ private:
 
 public:
     template <typename I, typename S, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> && permutable<I> &&
             indirect_relation<ranges::equal_to, projected<I, Proj>, const T*>,
         I>
@@ -48,7 +48,7 @@ public:
     }
 
     template <typename Rng, typename T, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> && permutable<iterator_t<Rng>> &&
             indirect_relation<ranges::equal_to, projected<iterator_t<Rng>, Proj>,
                              const T*>,

--- a/include/nanorange/algorithm/remove_if.hpp
+++ b/include/nanorange/algorithm/remove_if.hpp
@@ -38,7 +38,7 @@ private:
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> && permutable<I> &&
             indirect_unary_predicate<Pred, projected<I, Proj>>,
         I>
@@ -48,7 +48,7 @@ public:
     }
 
     template <typename Rng, typename Pred, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> && permutable<iterator_t<Rng>> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>>,
         borrowed_iterator_t<Rng>>

--- a/include/nanorange/algorithm/rotate.hpp
+++ b/include/nanorange/algorithm/rotate.hpp
@@ -53,14 +53,14 @@ private:
         while (i != j) {
             if (i > j) {
                 if (is_tma && j == 1) {
-                    do_rotate_one_right(middle - i, middle);
+                    (void)do_rotate_one_right(middle - i, middle);
                     return {std::move(out), nano::next(first, last)};
                 }
                 nano::swap_ranges(middle - i, unreachable_sentinel, middle, middle + j);
                 i -= j;
             } else {
                 if (is_tma && i == 1) {
-                    do_rotate_one_left(middle - i, middle + j);
+                    (void)do_rotate_one_left(middle - i, middle + j);
                     return {std::move(out), nano::next(first, last)};
                 }
                 nano::swap_ranges(middle - i, middle, middle + j - i, unreachable_sentinel);

--- a/include/nanorange/algorithm/search_n.hpp
+++ b/include/nanorange/algorithm/search_n.hpp
@@ -57,7 +57,7 @@ private:
 public:
     template <typename I, typename S, typename T, typename Pred = ranges::equal_to,
         typename Proj = identity>
-    constexpr auto operator()(I first, S last, iter_difference_t<I> count,
+    [[nodiscard]] constexpr auto operator()(I first, S last, iter_difference_t<I> count,
                               const T& value, Pred pred = Pred{},
                               Proj proj = Proj{}) const
     -> std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
@@ -70,7 +70,7 @@ public:
 
     template <typename Rng, typename T, typename Pred = ranges::equal_to,
         typename Proj = identity>
-    constexpr auto
+    [[nodiscard]] constexpr auto
     operator()(Rng&& rng, iter_difference_t<iterator_t<Rng>> count,
                const T& value, Pred pred = Pred{}, Proj proj = Proj{}) const
     -> std::enable_if_t<

--- a/include/nanorange/algorithm/stable_partition.hpp
+++ b/include/nanorange/algorithm/stable_partition.hpp
@@ -149,7 +149,7 @@ private:
 
 public:
     template <typename I, typename S, typename Pred, typename Proj = identity>
-    std::enable_if_t<bidirectional_iterator<I> && sentinel_for<S, I> &&
+    [[nodiscard]] std::enable_if_t<bidirectional_iterator<I> && sentinel_for<S, I> &&
                          indirect_unary_predicate<Pred, projected<I, Proj>> &&
                          permutable<I>, subrange<I>>
     operator()(I first, S last, Pred pred, Proj proj = Proj{}) const
@@ -159,7 +159,7 @@ public:
     }
 
     template <typename Rng, typename Pred, typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         bidirectional_range<Rng> &&
             indirect_unary_predicate<Pred, projected<iterator_t<Rng>, Proj>> &&
             permutable<iterator_t<Rng>>,

--- a/include/nanorange/algorithm/unique.hpp
+++ b/include/nanorange/algorithm/unique.hpp
@@ -41,7 +41,7 @@ private:
 public:
     template <typename I, typename S, typename R = ranges::equal_to,
               typename Proj = identity>
-    constexpr std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
+    [[nodiscard]] constexpr std::enable_if_t<forward_iterator<I> && sentinel_for<S, I> &&
                                    indirect_relation<R, projected<I, Proj>> &&
                                    permutable<I>, subrange<I>>
     operator()(I first, S last, R comp = {}, Proj proj = Proj{}) const
@@ -51,7 +51,7 @@ public:
     }
 
     template <typename Rng, typename R = ranges::equal_to, typename Proj = identity>
-    constexpr std::enable_if_t<
+    [[nodiscard]] constexpr std::enable_if_t<
         forward_range<Rng> &&
             indirect_relation<R, projected<iterator_t<Rng>, Proj>> &&
             permutable<iterator_t<Rng>>,

--- a/include/nanorange/algorithm/upper_bound.hpp
+++ b/include/nanorange/algorithm/upper_bound.hpp
@@ -41,7 +41,7 @@ private:
 public:
     template <typename I, typename S, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<
+    [[nodiscard]] std::enable_if_t<
         forward_iterator<I> && sentinel_for<S, I> &&
             indirect_strict_weak_order<Comp, const T*, projected<I, Proj>>,
     I>
@@ -54,7 +54,7 @@ public:
 
     template <typename Rng, typename T, typename Comp = ranges::less,
               typename Proj = identity>
-    std::enable_if_t<forward_range<Rng> &&
+    [[nodiscard]] std::enable_if_t<forward_range<Rng> &&
                          indirect_strict_weak_order<Comp, const T*, projected<iterator_t<Rng>, Proj>>,
                      borrowed_iterator_t<Rng>>
     constexpr operator()(Rng&& rng, const T& value, Comp comp = Comp{},

--- a/include/nanorange/detail/algorithm/result_types.hpp
+++ b/include/nanorange/detail/algorithm/result_types.hpp
@@ -132,7 +132,7 @@ struct in_out_out_result {
 };
 
 template <typename T>
-struct min_max_result {
+struct [[nodiscard]] min_max_result {
     NANO_NO_UNIQUE_ADDRESS T min;
     NANO_NO_UNIQUE_ADDRESS T max;
 

--- a/include/nanorange/views/all.hpp
+++ b/include/nanorange/views/all.hpp
@@ -43,7 +43,7 @@ private:
 
 public:
     template <typename T>
-    constexpr auto operator()(T&& t) const
+    [[nodiscard]] constexpr auto operator()(T&& t) const
         noexcept(noexcept(all_view_fn::impl(std::forward<T>(t), priority_tag<2>{})))
         -> decltype(all_view_fn::impl(std::forward<T>(t), priority_tag<2>{}))
     {

--- a/include/nanorange/views/common.hpp
+++ b/include/nanorange/views/common.hpp
@@ -125,7 +125,7 @@ private:
 
 public:
     template <typename T>
-    constexpr auto operator()(T&& t) const
+    [[nodiscard]] constexpr auto operator()(T&& t) const
         -> std::enable_if_t<
         viewable_range<T>,
         decltype(common_view_fn::impl(std::forward<T>(t),

--- a/include/nanorange/views/counted.hpp
+++ b/include/nanorange/views/counted.hpp
@@ -40,7 +40,7 @@ private:
 
 public:
     template <typename E, typename F, typename T = std::decay_t<E>>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         noexcept(noexcept(impl(std::forward<E>(e),
                                static_cast<iter_difference_t<T>>(std::forward<F>(f)),
                                nano::detail::priority_tag<1>{})))

--- a/include/nanorange/views/drop.hpp
+++ b/include/nanorange/views/drop.hpp
@@ -105,14 +105,14 @@ namespace detail {
 struct drop_view_fn {
 
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         -> decltype(drop_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return drop_view{std::forward<E>(e), std::forward<F>(f)};
     }
 
     template <typename C>
-    constexpr auto operator()(C c) const
+    [[nodiscard]] constexpr auto operator()(C c) const
     {
         return detail::rao_proxy{[c = std::move(c)](auto&& r) mutable
 #ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND

--- a/include/nanorange/views/drop_while.hpp
+++ b/include/nanorange/views/drop_while.hpp
@@ -66,14 +66,14 @@ namespace detail {
 struct drop_while_view_fn {
 
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         -> decltype(drop_while_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return drop_while_view{std::forward<E>(e), std::forward<F>(f)};
     }
 
     template <typename Pred>
-    constexpr auto operator()(Pred&& pred) const
+    [[nodiscard]] constexpr auto operator()(Pred&& pred) const
     {
         return detail::rao_proxy{[p = std::forward<Pred>(pred)](auto&& r) mutable
 #ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND

--- a/include/nanorange/views/elements.hpp
+++ b/include/nanorange/views/elements.hpp
@@ -311,7 +311,7 @@ namespace detail {
 template <std::size_t N>
 struct elements_view_fn {
     template <typename E>
-    constexpr auto operator()(E&& e) const
+    [[nodiscard]] constexpr auto operator()(E&& e) const
         -> decltype(elements_view<all_view<decltype(std::forward<E>(e))>, N>{std::forward<E>(e)})
     {
         return elements_view<all_view<decltype(std::forward<E>(e))>, N>{std::forward<E>(e)};

--- a/include/nanorange/views/empty.hpp
+++ b/include/nanorange/views/empty.hpp
@@ -14,7 +14,7 @@ NANO_BEGIN_NAMESPACE
 namespace empty_view_ {
 
 template <typename T>
-class empty_view : view_interface<empty_view<T>> {
+class [[nodiscard]] empty_view : view_interface<empty_view<T>> {
     static_assert(std::is_object<T>::value, "");
 
 public:

--- a/include/nanorange/views/filter.hpp
+++ b/include/nanorange/views/filter.hpp
@@ -248,7 +248,7 @@ namespace detail {
 
 struct filter_view_fn {
     template <typename Pred>
-    constexpr auto operator()(Pred pred) const
+    [[nodiscard]] constexpr auto operator()(Pred pred) const
     {
         return detail::rao_proxy{[p = std::move(pred)] (auto&& r) mutable
 #ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND
@@ -260,7 +260,7 @@ struct filter_view_fn {
     }
 
     template <typename R, typename Pred>
-    constexpr auto operator()(R&& r, Pred pred) const
+    [[nodiscard]] constexpr auto operator()(R&& r, Pred pred) const
         noexcept(noexcept(filter_view{std::forward<R>(r), std::move(pred)}))
         -> decltype(filter_view{std::forward<R>(r), std::move(pred)})
     {

--- a/include/nanorange/views/iota.hpp
+++ b/include/nanorange/views/iota.hpp
@@ -363,7 +363,7 @@ namespace detail {
 
 struct iota_view_fn {
     template <typename W>
-    constexpr auto operator()(W&& value) const
+    [[nodiscard]] constexpr auto operator()(W&& value) const
         noexcept(noexcept(iota_view{std::forward<W>(value)}))
         -> decltype(iota_view(std::forward<W>(value)))
     {
@@ -371,7 +371,7 @@ struct iota_view_fn {
     }
 
     template <typename W, typename Bound>
-    constexpr auto operator()(W&& value, Bound&& bound) const
+    [[nodiscard]] constexpr auto operator()(W&& value, Bound&& bound) const
         noexcept(noexcept(iota_view{std::forward<W>(value), std::forward<Bound>(bound)}))
         -> decltype(iota_view(std::forward<W>(value), std::forward<Bound>(bound)))
     {

--- a/include/nanorange/views/istream.hpp
+++ b/include/nanorange/views/istream.hpp
@@ -30,7 +30,7 @@ NANO_CONCEPT StreamExtractable =
 } // namespace detail
 
 template <typename Val, typename CharT, typename Traits = std::char_traits<CharT>>
-struct basic_istream_view : view_interface<basic_istream_view<Val, CharT, Traits>> {
+struct [[nodiscard]] basic_istream_view : view_interface<basic_istream_view<Val, CharT, Traits>> {
 
     static_assert(movable<Val>);
     static_assert(default_initializable<Val>);

--- a/include/nanorange/views/join.hpp
+++ b/include/nanorange/views/join.hpp
@@ -353,7 +353,7 @@ namespace detail {
 struct join_view_fn {
 
     template <typename E>
-    constexpr auto operator()(E&& e) const
+    [[nodiscard]] constexpr auto operator()(E&& e) const
         -> decltype(join_view{std::forward<E>(e)})
     {
         return join_view{std::forward<E>(e)};

--- a/include/nanorange/views/ref.hpp
+++ b/include/nanorange/views/ref.hpp
@@ -14,7 +14,7 @@ NANO_BEGIN_NAMESPACE
 namespace ref_view_ {
 
 template <typename R>
-class ref_view : public view_interface<ref_view<R>> {
+class [[nodiscard]] ref_view : public view_interface<ref_view<R>> {
 
     static_assert(range<R> && std::is_object<R>::value, "");
 

--- a/include/nanorange/views/reverse.hpp
+++ b/include/nanorange/views/reverse.hpp
@@ -124,7 +124,7 @@ private:
 
 public:
     template <typename R>
-    constexpr auto operator()(R&& r) const
+    [[nodiscard]] constexpr auto operator()(R&& r) const
         -> decltype(impl(std::forward<R>(r), priority_tag<1>{}))
     {
         return impl(std::forward<R>(r), priority_tag<1>{});

--- a/include/nanorange/views/single.hpp
+++ b/include/nanorange/views/single.hpp
@@ -54,7 +54,7 @@ namespace detail {
 
 struct single_view_fn {
     template <typename T>
-    constexpr auto operator()(T&& t) const
+    [[nodiscard]] constexpr auto operator()(T&& t) const
         noexcept(noexcept(single_view{std::forward<T>(t)}))
         -> decltype(single_view{std::forward<T>(t)})
     {

--- a/include/nanorange/views/split.hpp
+++ b/include/nanorange/views/split.hpp
@@ -425,14 +425,14 @@ namespace detail {
 struct split_view_fn {
 
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         -> decltype(split_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return split_view{std::forward<E>(e), std::forward<F>(f)};
     }
 
     template <typename P>
-    constexpr auto operator()(P&& p) const
+    [[nodiscard]] constexpr auto operator()(P&& p) const
     {
         return detail::rao_proxy{
             [p = std::forward<P>(p)](auto&& r) mutable

--- a/include/nanorange/views/subrange.hpp
+++ b/include/nanorange/views/subrange.hpp
@@ -172,7 +172,7 @@ constexpr subrange_kind subrange_deduction_guide_helper()
 namespace subrange_ {
 
 template <typename I, typename S, subrange_kind K>
-class subrange : public view_interface<subrange<I, S, K>> {
+class [[nodiscard]] subrange : public view_interface<subrange<I, S, K>> {
     static_assert(input_or_output_iterator<I>);
     static_assert(sentinel_for<S, I>);
     static_assert(K == subrange_kind::sized || !sized_sentinel_for<S, I>, "");

--- a/include/nanorange/views/take.hpp
+++ b/include/nanorange/views/take.hpp
@@ -172,7 +172,7 @@ using take_view_helper_t = take_view<all_view<R>>;
 struct take_view_fn {
 
     template <typename C>
-    constexpr auto operator()(C c) const
+    [[nodiscard]] constexpr auto operator()(C c) const
     {
 
         return detail::rao_proxy{[c = std::move(c)](auto&& r) mutable
@@ -187,7 +187,7 @@ struct take_view_fn {
     }
 
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         -> decltype(take_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return take_view{std::forward<E>(e), std::forward<F>(f)};

--- a/include/nanorange/views/take_while.hpp
+++ b/include/nanorange/views/take_while.hpp
@@ -128,14 +128,14 @@ namespace detail {
 struct take_while_view_fn {
 
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
     -> decltype(take_while_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return take_while_view{std::forward<E>(e), std::forward<F>(f)};
     }
 
     template <typename Pred>
-    constexpr auto operator()(Pred&& pred) const
+    [[nodiscard]] constexpr auto operator()(Pred&& pred) const
     {
         return detail::rao_proxy{[p = std::forward<Pred>(pred)](auto&& r) mutable
 #ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND

--- a/include/nanorange/views/transform.hpp
+++ b/include/nanorange/views/transform.hpp
@@ -360,14 +360,14 @@ namespace detail {
 
 struct transform_view_fn {
     template <typename E, typename F>
-    constexpr auto operator()(E&& e, F&& f) const
+    [[nodiscard]] constexpr auto operator()(E&& e, F&& f) const
         -> decltype(transform_view{std::forward<E>(e), std::forward<F>(f)})
     {
         return transform_view{std::forward<E>(e), std::forward<F>(f)};
     }
 
     template <typename F>
-    constexpr auto operator()(F f) const
+    [[nodiscard]] constexpr auto operator()(F f) const
     {
         return detail::rao_proxy{[f = std::move(f)](auto&& r) mutable
 #ifndef NANO_MSVC_LAMBDA_PIPE_WORKAROUND

--- a/test/algorithm/equal_range.cpp
+++ b/test/algorithm/equal_range.cpp
@@ -42,7 +42,7 @@ void not_totally_ordered()
 {
 	// This better compile!
 	std::vector<my_int> vec;
-	ranges::equal_range(vec, my_int{10}, compare);
+	(void)ranges::equal_range(vec, my_int{10}, compare);
 }
 
 template <class Iter, class Sent, class T, class Proj = ranges::identity>

--- a/test/algorithm/lower_bound.cpp
+++ b/test/algorithm/lower_bound.cpp
@@ -37,7 +37,7 @@ void not_totally_ordered()
 {
 	// This better compile!
 	std::vector<my_int> vec;
-	stl2::lower_bound(vec, my_int{10}, compare);
+	(void)stl2::lower_bound(vec, my_int{10}, compare);
 }
 
 }

--- a/test/algorithm/upper_bound.cpp
+++ b/test/algorithm/upper_bound.cpp
@@ -36,7 +36,7 @@ void not_totally_ordered()
 {
 	// This better compile!
 	std::vector<my_int> vec;
-	stl2::upper_bound(vec, my_int{10}, compare);
+	(void)stl2::upper_bound(vec, my_int{10}, compare);
 }
 
 }

--- a/test/basic_algorithm/modifying_seq_ops.cpp
+++ b/test/basic_algorithm/modifying_seq_ops.cpp
@@ -508,13 +508,13 @@ TEST_CASE("alg.basic.rotate")
 
     SECTION("with iterators") {
         const std::vector<int> result{2, 3, 4, 5, 1};
-        rng::rotate(vec.begin(), vec.begin() + 1, vec.end());
+        (void)rng::rotate(vec.begin(), vec.begin() + 1, vec.end());
         REQUIRE(vec == result);
     }
 
     SECTION("with range") {
         const std::vector<int> result{2, 3, 4, 5, 1};
-        rng::rotate(vec, vec.begin() + 1);
+        (void)rng::rotate(vec, vec.begin() + 1);
         REQUIRE(vec == result);
     }
 }

--- a/test/basic_algorithm/partitioning_ops.cpp
+++ b/test/basic_algorithm/partitioning_ops.cpp
@@ -32,11 +32,11 @@ TEST_CASE("alg.basic.partition")
     const auto is_even = [](int i) { return i % 2 == 0; };
 
     SECTION("with iterators") {
-        rng::partition(vec.begin(), vec.end(), is_even);
+        (void)rng::partition(vec.begin(), vec.end(), is_even);
     }
 
     SECTION("witn range") {
-        rng::partition(vec, is_even);
+        (void)rng::partition(vec, is_even);
     }
 
     REQUIRE(std::is_partitioned(vec.begin(), vec.end(), is_even));
@@ -77,11 +77,11 @@ TEST_CASE("alg.basic.stable_partition")
     }();
 
     SECTION("with iterators") {
-        rng::stable_partition(src.begin(), src.end(), is_even);
+        (void)rng::stable_partition(src.begin(), src.end(), is_even);
     }
 
     SECTION("with range") {
-        rng::stable_partition(src, is_even);
+        (void)rng::stable_partition(src, is_even);
     }
 
     REQUIRE(src == test);

--- a/test/views/filter_view.cpp
+++ b/test/views/filter_view.cpp
@@ -140,7 +140,7 @@ TEST_CASE("views.filter")
     {
         auto yes = [](int) { return true; };
         auto const rng = views::iota(0) | views::filter(yes);
-        views::all(rng);
+        (void)views::all(rng);
     }
 
     {


### PR DESCRIPTION
All views are now marked with `[[nodiscard]]`, although some things may have been missed.
For algorithms, `[[nodiscard]]` wasn't added to:

1. In-place, modifying algorithms - the caller often knows what to expect and the return value isn't that useful.
2. Algorithms that take an output iterator - that output iterator might be `ostream_iterator<T>(cout)`.
3. `next_permutation` and `prev_permutation` - the `in_found_result::found` seems useful, but I wasn't sure if it is useful enough.