### PR TITLE
Prevent min / max macro expansion on Windows

### DIFF
--- a/include/nanorange/algorithm/inplace_merge.hpp
+++ b/include/nanorange/algorithm/inplace_merge.hpp
@@ -172,7 +172,7 @@ private:
             ++dist2;
         }
 
-        const auto sz = nano::min(dist1, dist2);
+        const auto sz = (nano::min)(dist1, dist2);
         auto buf = detail::temporary_vector<iter_value_t<I>>(sz);
 
         if (buf.capacity() >= static_cast<std::size_t>(sz)) {

--- a/include/nanorange/algorithm/sample.hpp
+++ b/include/nanorange/algorithm/sample.hpp
@@ -34,7 +34,7 @@ private:
 
         auto unsampled_size = nano::distance(first, last);
 
-        for (n = nano::min(n, unsampled_size); n != 0; ++first) {
+        for (n = (nano::min)(n, unsampled_size); n != 0; ++first) {
             if (D(g, param_t(0, --unsampled_size)) < n) {
                 *out++ = *first;
                 --n;
@@ -64,7 +64,7 @@ private:
             }
         }
 
-        return out + nano::min(n, k);
+        return out + (nano::min)(n, k);
     }
 
     template <typename I, typename S, typename O, typename Gen>

--- a/include/nanorange/algorithm/stable_sort.hpp
+++ b/include/nanorange/algorithm/stable_sort.hpp
@@ -130,7 +130,7 @@ private:
                          result, std::ref(comp), std::ref(proj), std::ref(proj)).out;
             first += two_step;
         }
-        step_size = nano::min(iter_difference_t<I>(last - first), step_size);
+        step_size = (nano::min)(iter_difference_t<I>(last - first), step_size);
         nano::merge(
                 nano::make_move_iterator(first),
                 nano::make_move_iterator(first + step_size),

--- a/include/nanorange/random.hpp
+++ b/include/nanorange/random.hpp
@@ -29,8 +29,8 @@ struct uniform_random_bit_generator_concept {
 
     template <typename G>
     auto requires_() -> decltype(
-        requires_expr<same_as<decltype(G::min()), invoke_result_t<G&>>>{},
-        requires_expr<same_as<decltype(G::max()), invoke_result_t<G&>>>{}
+        requires_expr<same_as<decltype((G::min)()), invoke_result_t<G&>>>{},
+        requires_expr<same_as<decltype((G::max)()), invoke_result_t<G&>>>{}
     );
 };
 

--- a/include/nanorange/views/take.hpp
+++ b/include/nanorange/views/take.hpp
@@ -148,14 +148,14 @@ public:
     constexpr auto size()
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 
     template <typename VV = V, std::enable_if_t<sized_range<const VV>, int> = 0>
     constexpr auto size() const
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 };
 

--- a/single_include/nanorange.hpp
+++ b/single_include/nanorange.hpp
@@ -12630,8 +12630,8 @@ struct uniform_random_bit_generator_concept {
 
     template <typename G>
     auto requires_() -> decltype(
-        requires_expr<same_as<decltype(G::min()), invoke_result_t<G&>>>{},
-        requires_expr<same_as<decltype(G::max()), invoke_result_t<G&>>>{}
+        requires_expr<same_as<decltype((G::min)()), invoke_result_t<G&>>>{},
+        requires_expr<same_as<decltype((G::max)()), invoke_result_t<G&>>>{}
     );
 };
 

--- a/single_include/nanorange.hpp
+++ b/single_include/nanorange.hpp
@@ -1938,7 +1938,7 @@ NANO_CONCEPT input_or_output_iterator =
 
 template <typename S, typename I>
 NANO_CONCEPT sentinel_for =
-    semiregular<S> && input_or_output_iterator<I> && 
+    semiregular<S> && input_or_output_iterator<I> &&
     detail::weakly_equality_comparable_with<S, I>;
 
 // [iterator.concept.sizedsentinel]
@@ -8796,7 +8796,7 @@ private:
             ++dist2;
         }
 
-        const auto sz = nano::min(dist1, dist2);
+        const auto sz = (nano::min)(dist1, dist2);
         auto buf = detail::temporary_vector<iter_value_t<I>>(sz);
 
         if (buf.capacity() >= static_cast<std::size_t>(sz)) {
@@ -12666,7 +12666,7 @@ private:
 
         auto unsampled_size = nano::distance(first, last);
 
-        for (n = nano::min(n, unsampled_size); n != 0; ++first) {
+        for (n = (nano::min)(n, unsampled_size); n != 0; ++first) {
             if (D(g, param_t(0, --unsampled_size)) < n) {
                 *out++ = *first;
                 --n;
@@ -12696,7 +12696,7 @@ private:
             }
         }
 
-        return out + nano::min(n, k);
+        return out + (nano::min)(n, k);
     }
 
     template <typename I, typename S, typename O, typename Gen>
@@ -13839,7 +13839,7 @@ private:
                          result, std::ref(comp), std::ref(proj), std::ref(proj)).out;
             first += two_step;
         }
-        step_size = nano::min(iter_difference_t<I>(last - first), step_size);
+        step_size = (nano::min)(iter_difference_t<I>(last - first), step_size);
         nano::merge(
                 nano::make_move_iterator(first),
                 nano::make_move_iterator(first + step_size),
@@ -18606,14 +18606,14 @@ public:
     constexpr auto size()
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 
     template <typename VV = V, std::enable_if_t<sized_range<const VV>, int> = 0>
     constexpr auto size() const
     {
         auto n = ranges::size(base_);
-        return ranges::min(n, static_cast<decltype(n)>(count_));
+        return (ranges::min)(n, static_cast<decltype(n)>(count_));
     }
 };
 


### PR DESCRIPTION
On Windows some modules might includes the windows.h header, which then defines macros for min and max, among other macros. The uniform_random_bit_generator_concept is susceptible to this problem and fails to compile.

The proper way of handling this issue is to prevent the macro expansion by enclosing the macro names in parenthesis.

The other known workaround is to define the NOMINMAX macro (but this is user-configurable and not suitable for libraries).